### PR TITLE
1. Upgrade 2.11.4 + Separation owner/manager

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.6.3
-starknet-foundry 0.21.0
+scarb 2.11.4
+starknet-foundry 0.46.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,52 +2,32 @@
 version = 1
 
 [[package]]
-name = "alexandria_data_structures"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=e7b6957#e7b69575f92076e96a83a76efa6bed3c32a15f9f"
-dependencies = [
- "alexandria_encoding",
-]
-
-[[package]]
-name = "alexandria_encoding"
-version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=e7b6957#e7b69575f92076e96a83a76efa6bed3c32a15f9f"
-dependencies = [
- "alexandria_math",
- "alexandria_numeric",
-]
-
-[[package]]
 name = "alexandria_math"
-version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=e7b6957#e7b69575f92076e96a83a76efa6bed3c32a15f9f"
-dependencies = [
- "alexandria_data_structures",
-]
-
-[[package]]
-name = "alexandria_numeric"
-version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=e7b6957#e7b69575f92076e96a83a76efa6bed3c32a15f9f"
-dependencies = [
- "alexandria_math",
-]
+version = "0.5.1"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c804e98#c804e98e6e9dc1677906bd65d44470615e42dabf"
 
 [[package]]
 name = "ekubo"
 version = "0.1.0"
-source = "git+https://github.com/EkuboProtocol/abis#946e1f3f97d48918d7cbd484de56bb2de8dd755e"
+source = "git+https://github.com/EkuboProtocol/abis#f4a16b95967c5596d5a3cd4e0422bb9a2e3eb017"
+
+[[package]]
+name = "snforge_scarb_plugin"
+version = "0.46.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.46.0#8586208d79496a1ccca23b9211e4f6ac910a8070"
 
 [[package]]
 name = "snforge_std"
-version = "0.21.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.21.0#2996b8c1dd66b2715fc67e69578089f278a46790"
+version = "0.46.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.46.0#8586208d79496a1ccca23b9211e4f6ac910a8070"
+dependencies = [
+ "snforge_scarb_plugin",
+]
 
 [[package]]
 name = "vesu"
 version = "0.1.0"
-source = "git+https://github.com/vesuxyz/vesu-v1#78cf26dd88c309a9d267e5968030e927a60cffcb"
+source = "git+https://github.com/vesuxyz/vesu-v1?branch=feat%2F2.11.4#bf617fb4ebea13250d651e5d471d0c66ee872a39"
 dependencies = [
  "alexandria_math",
  "snforge_std",
@@ -57,6 +37,7 @@ dependencies = [
 name = "vesu_periphery"
 version = "0.1.0"
 dependencies = [
+ "alexandria_math",
  "ekubo",
  "snforge_std",
  "vesu",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,17 +1,19 @@
 [package]
 name = "vesu_periphery"
 version = "0.1.0"
-edition = "2023_11"
+edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.6.3"
+starknet = "2.11.4"
 ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "946e1f3f97d48918d7cbd484de56bb2de8dd755e" }
-vesu = { git = "https://github.com/vesuxyz/vesu-v1", commit = "d790f0ca090fe9e5025360d6e11f768d70938f76" }
+vesu = { git = "https://github.com/vesuxyz/vesu-v1", branch = "feat/2.11.4" }
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c804e98" }
+
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.21.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.46.0" }
 
 [[target.starknet-contract]]
 casm = true

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,7 +11,6 @@ ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "946e1f3f97d48
 vesu = { git = "https://github.com/vesuxyz/vesu-v1", branch = "feat/2.11.4" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c804e98" }
 
-
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.46.0" }
 

--- a/Scarb.toml.template
+++ b/Scarb.toml.template
@@ -12,7 +12,7 @@ vesu = { git = "https://github.com/vesuxyz/vesu-v1", branch = "feat/2.11.4" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c804e98" }
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.21.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.46.0" }
 
 [[target.starknet-contract]]
 casm = true

--- a/Scarb.toml.template
+++ b/Scarb.toml.template
@@ -1,14 +1,15 @@
 [package]
 name = "vesu_periphery"
 version = "0.1.0"
-edition = "2023_11"
+edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.6.3"
+starknet = "2.11.4"
 ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "946e1f3f97d48918d7cbd484de56bb2de8dd755e" }
-vesu = { git = "https://github.com/vesuxyz/vesu-v1", commit = "78cf26dd88c309a9d267e5968030e927a60cffcb" }
+vesu = { git = "https://github.com/vesuxyz/vesu-v1", branch = "feat/2.11.4" }
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c804e98" }
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.21.0" }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,10 +1,15 @@
-pub mod swap;
+pub mod liquidate;
+pub mod managed_vault;
 pub mod multiply;
 pub mod multiply4626;
-pub mod liquidate;
-pub mod rebalance;
 pub mod proxy;
-pub mod managed_vault;
+pub mod rebalance;
+pub mod swap;
 pub mod utils {
     pub mod position_list;
+}
+use ekubo::types::i129::i129;
+
+pub fn i129_new(mag: u128, sign: bool) -> i129 {
+    i129 { mag, sign: sign & (mag != 0) }
 }

--- a/src/liquidate.cairo
+++ b/src/liquidate.cairo
@@ -1,6 +1,4 @@
-use ekubo::types::i129::{i129};
-use ekubo::types::keys::{PoolKey};
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 use vesu_periphery::swap::Swap;
 
 #[derive(Serde, Drop, Clone)]
@@ -17,7 +15,7 @@ pub struct LiquidateParams {
     pub liquidate_swap_weights: Array<u128>,
     pub withdraw_swap: Array<Swap>,
     pub withdraw_swap_limit_amount: u128,
-    pub withdraw_swap_weights: Array<u128>
+    pub withdraw_swap_weights: Array<u128>,
 }
 
 #[derive(Serde, Copy, Drop)]
@@ -25,7 +23,7 @@ pub struct LiquidateResponse {
     pub liquidated_collateral: u256,
     pub repaid_debt: u256,
     pub residual_collateral: u256,
-    pub residual_token: ContractAddress
+    pub residual_token: ContractAddress,
 }
 
 #[starknet::interface]
@@ -35,36 +33,29 @@ pub trait ILiquidate<TContractState> {
 
 #[starknet::contract]
 pub mod Liquidate {
-    use starknet::{ContractAddress, get_contract_address};
     // use core::num::traits::{Zero};
 
-    use ekubo::{
-        components::{shared_locker::{consume_callback_data, handle_delta, call_core_with_callback}},
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129, i129Trait, i129_new}, delta::{Delta}, keys::{PoolKey}}
+    use alexandria_math::i257::I257Trait;
+    use ekubo::components::shared_locker::{
+        call_core_with_callback, consume_callback_data, handle_delta,
     };
-
-    use vesu::{
-        singleton::{ISingleton, ISingletonDispatcher, ISingletonDispatcherTrait},
-        data_model::{LiquidatePositionParams, Amount, UpdatePositionResponse},
-        extension::components::position_hooks::LiquidationData, common::{i257, i257_new},
-        units::{SCALE, SCALE_128}
-    };
-
+    use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_contract_address};
+    use vesu::data_model::{LiquidatePositionParams, UpdatePositionResponse};
+    use vesu::extension::components::position_hooks::LiquidationData;
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
     use vesu_periphery::swap::{
-        RouteNode, TokenAmount, Swap, swap, apply_weights, assert_empty_token_amounts,
-        assert_matching_token_amounts
+        apply_weights, assert_empty_token_amounts, assert_matching_token_amounts, swap,
     };
-
+    use crate::i129_new;
     use super::{ILiquidate, LiquidateParams, LiquidateResponse};
 
     #[storage]
     struct Storage {
         core: ICoreDispatcher,
-        singleton: ISingletonDispatcher
+        singleton: ISingletonV2Dispatcher,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -79,18 +70,18 @@ pub mod Liquidate {
         user: ContractAddress,
         residual: u256,
         collateral_delta: u256,
-        debt_delta: u256
+        debt_delta: u256,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        LiquidatePosition: LiquidatePosition
+        LiquidatePosition: LiquidatePosition,
     }
 
     #[constructor]
     fn constructor(
-        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonDispatcher
+        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonV2Dispatcher,
     ) {
         self.core.write(core);
         self.singleton.write(singleton);
@@ -99,22 +90,23 @@ pub mod Liquidate {
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
         fn liquidate_position(
-            ref self: ContractState, liquidate_params: LiquidateParams
+            ref self: ContractState, liquidate_params: LiquidateParams,
         ) -> LiquidateResponse {
-            let LiquidateParams { pool_id,
-            collateral_asset,
-            debt_asset,
-            user,
-            recipient,
-            min_collateral_to_receive,
-            mut debt_to_repay,
-            mut liquidate_swap,
-            liquidate_swap_limit_amount,
-            liquidate_swap_weights,
-            mut withdraw_swap,
-            withdraw_swap_limit_amount,
-            withdraw_swap_weights } =
-                liquidate_params;
+            let LiquidateParams {
+                pool_id,
+                collateral_asset,
+                debt_asset,
+                user,
+                recipient,
+                min_collateral_to_receive,
+                mut debt_to_repay,
+                mut liquidate_swap,
+                liquidate_swap_limit_amount,
+                liquidate_swap_weights,
+                mut withdraw_swap,
+                withdraw_swap_limit_amount,
+                withdraw_swap_weights,
+            } = liquidate_params;
 
             let core = self.core.read();
 
@@ -131,38 +123,42 @@ pub mod Liquidate {
                 core,
                 debt_asset,
                 i129_new(debt_to_repay.try_into().unwrap(), true),
-                get_contract_address()
+                get_contract_address(),
             );
 
             assert!(
                 IERC20Dispatcher { contract_address: debt_asset }
                     .approve(singleton.contract_address, debt),
-                "approve-failed"
+                "approve-failed",
             );
 
             let liquidation_data = LiquidationData { min_collateral_to_receive, debt_to_repay };
             let mut data: Array<felt252> = array![];
             Serde::serialize(@liquidation_data, ref data);
 
-            let UpdatePositionResponse { collateral_delta, debt_delta, bad_debt, .. } = self
-                .singleton
-                .read()
-                .liquidate_position(
-                    LiquidatePositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        receive_as_shares: false,
-                        data: data.span()
-                    }
-                );
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, bad_debt, ..,
+            } =
+                self
+                    .singleton
+                    .read()
+                    .liquidate_position(
+                        LiquidatePositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            receive_as_shares: false,
+                            data: data.span(),
+                        },
+                    );
 
-            let debt_paid = debt_delta.abs - bad_debt;
+            let debt_paid = debt_delta.abs() - bad_debt;
 
             // - swap collateral asset to debt asset (1.)
             // for repaying an exact amount of debt:
-            //   - input token: debt asset and output token: collateral asset, since we specify a negative input amount
+            //   - input token: debt asset and output token: collateral asset, since we specify a
+            //   negative input amount
             //     of the debt asset (swap direction is reversed)
             assert_matching_token_amounts(liquidate_swap.clone());
             assert_empty_token_amounts(liquidate_swap.clone());
@@ -172,11 +168,11 @@ pub mod Liquidate {
                     // debt_paid.try_into().unwrap()
                     liquidate_swap,
                     liquidate_swap_weights,
-                    i129_new(debt_paid.try_into().unwrap(), true)
+                    i129_new(debt_paid.try_into().unwrap(), true),
                 );
 
             let (collateral_amount, debt_amount) = swap(
-                core, liquidate_swap.clone(), liquidate_swap_limit_amount
+                core, liquidate_swap.clone(), liquidate_swap_limit_amount,
             );
             assert!(collateral_amount.token == collateral_asset, "invalid-liquidate-swap-assets");
 
@@ -185,7 +181,7 @@ pub mod Liquidate {
                 core,
                 debt_amount.token,
                 i129_new((debt_to_repay - debt_paid).try_into().unwrap(), false),
-                get_contract_address()
+                get_contract_address(),
             );
 
             // - handleDelta: settle collateral asset swap (1.)
@@ -193,10 +189,10 @@ pub mod Liquidate {
                 core,
                 collateral_amount.token,
                 i129_new(collateral_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
 
-            let residual_collateral = collateral_delta.abs.try_into().unwrap()
+            let residual_collateral = collateral_delta.abs().try_into().unwrap()
                 - collateral_amount.amount.mag;
 
             self
@@ -207,9 +203,9 @@ pub mod Liquidate {
                         debt_asset,
                         user,
                         residual: residual_collateral.into(),
-                        collateral_delta: collateral_delta.abs,
-                        debt_delta: debt_delta.abs.try_into().unwrap()
-                    }
+                        collateral_delta: collateral_delta.abs(),
+                        debt_delta: debt_delta.abs().try_into().unwrap(),
+                    },
                 );
 
             // avoid withdraw_swap moving error by returning early here
@@ -217,13 +213,13 @@ pub mod Liquidate {
                 assert!(
                     IERC20Dispatcher { contract_address: collateral_asset }
                         .transfer(recipient, residual_collateral.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
                 return LiquidateResponse {
-                    liquidated_collateral: collateral_delta.abs,
-                    repaid_debt: debt_delta.abs,
+                    liquidated_collateral: collateral_delta.abs(),
+                    repaid_debt: debt_delta.abs(),
                     residual_collateral: residual_collateral.into(),
-                    residual_token: collateral_asset
+                    residual_token: collateral_asset,
                 };
             }
 
@@ -233,28 +229,28 @@ pub mod Liquidate {
             // apply weights to withdraw_swap token amounts
             withdraw_swap =
                 apply_weights(
-                    withdraw_swap, withdraw_swap_weights, residual_collateral.try_into().unwrap()
+                    withdraw_swap, withdraw_swap_weights, residual_collateral.try_into().unwrap(),
                 );
 
             // collateral_asset to arbitrary_asset
             // token_amount is always positive, limit_amount is min. amount out:
             let (collateral_margin_amount, out_amount) = swap(
-                core, withdraw_swap.clone(), withdraw_swap_limit_amount
+                core, withdraw_swap.clone(), withdraw_swap_limit_amount,
             );
 
             handle_delta(
                 core,
                 collateral_margin_amount.token,
                 i129_new(collateral_margin_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
             handle_delta(core, out_amount.token, i129_new(out_amount.amount.mag, true), recipient);
 
             return LiquidateResponse {
-                liquidated_collateral: collateral_delta.abs,
-                repaid_debt: debt_delta.abs,
+                liquidated_collateral: collateral_delta.abs(),
+                repaid_debt: debt_delta.abs(),
                 residual_collateral: out_amount.amount.mag.into(),
-                residual_token: out_amount.token
+                residual_token: out_amount.token,
             };
         }
     }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -304,6 +304,7 @@ pub mod ManagedVault {
 
         /// Re-approves the vToken to be spendable by the extension
         fn approve_singleton(ref self: ContractState) {
+            self.assert_owner();
             self.asset.read().approve(self.singleton.read().contract_address, Bounded::MAX);
         }
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -1,11 +1,7 @@
-use starknet::{account::Call, ContractAddress};
-use vesu::{common::{i257, i257_new}, data_model::{Amount, UpdatePositionResponse}};
-use vesu_periphery::{
-    swap::Swap,
-    multiply::{
-        IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverParams, ModifyLeverResponse
-    }
-};
+use starknet::ContractAddress;
+use vesu::data_model::{Amount, UpdatePositionResponse};
+use vesu_periphery::multiply::{ModifyLeverParams, ModifyLeverResponse};
+use vesu_periphery::swap::Swap;
 
 #[starknet::interface]
 trait IERC4626<TContractState> {
@@ -22,12 +18,12 @@ trait IERC4626<TContractState> {
     fn max_withdraw(self: @TContractState, owner: ContractAddress) -> u256;
     fn preview_withdraw(self: @TContractState, assets: u256) -> u256;
     fn withdraw(
-        ref self: TContractState, assets: u256, receiver: ContractAddress, owner: ContractAddress
+        ref self: TContractState, assets: u256, receiver: ContractAddress, owner: ContractAddress,
     ) -> u256;
     fn max_redeem(self: @TContractState, owner: ContractAddress) -> u256;
     fn preview_redeem(self: @TContractState, shares: u256) -> u256;
     fn redeem(
-        ref self: TContractState, shares: u256, receiver: ContractAddress, owner: ContractAddress
+        ref self: TContractState, shares: u256, receiver: ContractAddress, owner: ContractAddress,
     ) -> u256;
 }
 
@@ -40,19 +36,21 @@ pub struct Claim {
 
 #[starknet::interface]
 pub trait IManagedVault<TContractState> {
+    // Owner functions
     fn set_manager(ref self: TContractState, manager: ContractAddress);
     fn set_price_source(ref self: TContractState, extension: ContractAddress, pool_id: felt252);
     fn price_source(self: @TContractState) -> (ContractAddress, felt252);
-    fn modify_delegation(
-        ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool
-    );
     fn set_redemption_timeout(ref self: TContractState, timeout: u64);
-    fn approve_singleton(ref self: TContractState);
+    fn modify_delegation(
+        ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
+    );
+
+    // Management functions
     fn claim_rewards(
         ref self: TContractState,
         rewards_contract: ContractAddress,
         claim: Claim,
-        proof: Span<felt252>
+        proof: Span<felt252>,
     );
     fn swap(ref self: TContractState, swap: Array<Swap>, limit_amount: u128);
     fn modify_position(
@@ -61,13 +59,14 @@ pub trait IManagedVault<TContractState> {
         collateral_asset: ContractAddress,
         debt_asset: ContractAddress,
         collateral: Amount,
-        debt: Amount
+        debt: Amount,
     ) -> UpdatePositionResponse;
     fn modify_lever(
-        ref self: TContractState, modify_lever_params: ModifyLeverParams
+        ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
 
+    // User related functions
     fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
     fn mint(ref self: TContractState, shares: u256, receiver: ContractAddress) -> u256;
 
@@ -83,50 +82,40 @@ pub trait IMerkleDistributor<TContractState> {
 #[derive(Serde, Drop, Clone)]
 pub struct SwapParams {
     pub swap: Array<Swap>,
-    pub limit_amount: u128
+    pub limit_amount: u128,
 }
 
 #[starknet::contract]
 pub mod ManagedVault {
-    use core::integer::BoundedInt;
-    use core::num::traits::{Zero};
-
-    use starknet::{
-        account::Call, syscalls::call_contract_syscall, ContractAddress, get_caller_address,
-        get_contract_address, get_block_timestamp
+    use core::num::traits::{Bounded, Zero};
+    use ekubo::components::shared_locker::{
+        call_core_with_callback, consume_callback_data, handle_delta,
     };
-    use ekubo::{
-        components::{shared_locker::{consume_callback_data, handle_delta, call_core_with_callback}},
-        interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters}
+    use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
-    use vesu::{
-        data_model::{
-            ModifyPositionParams, Amount, AmountType, AmountDenomination, AssetConfig,
-            UpdatePositionResponse
-        },
-        units::SCALE, singleton::{Singleton, ISingletonDispatcher, ISingletonDispatcherTrait},
-        v_token::{IVToken, IVTokenDispatcher, IVTokenDispatcherTrait},
-        vendor::{
-            erc20::{ERC20ABIDispatcher as IERC20Dispatcher, ERC20ABIDispatcherTrait},
-            erc20_component::ERC20Component
-        },
-        common::{i257, i257_new, calculate_collateral_and_debt_value}, math::pow_10,
-        extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait}
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
+    use vesu::common::calculate_collateral_and_debt_value;
+    use vesu::data_model::{Amount, ModifyPositionParams, UpdatePositionResponse};
+    use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
+    use vesu::math::pow_10;
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::units::SCALE;
+    use vesu::vendor::erc20::{ERC20ABIDispatcher as IERC20Dispatcher, ERC20ABIDispatcherTrait};
+    use vesu::vendor::erc20_component::ERC20Component;
+    use vesu_periphery::managed_vault::{
+        Claim, IManagedVault, IMerkleDistributorDispatcher, IMerkleDistributorDispatcherTrait,
+        SwapParams,
     };
-    use vesu_periphery::{
-        swap::{swap, Swap},
-        managed_vault::{
-            IManagedVault, Claim, IMerkleDistributorDispatcher, IMerkleDistributorDispatcherTrait,
-            SwapParams
-        },
-        multiply::{
-            IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverParams, ModifyLeverResponse,
-            ModifyLeverAction
-        },
-        utils::position_list::{
-            position_list_component, position_list_component::PositionListTrait, Position
-        },
+    use vesu_periphery::multiply::{
+        IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverAction, ModifyLeverParams,
+        ModifyLeverResponse,
     };
+    use vesu_periphery::swap::{Swap, swap};
+    use vesu_periphery::utils::position_list::position_list_component::PositionListTrait;
+    use vesu_periphery::utils::position_list::{Position, position_list_component};
 
     component!(path: position_list_component, storage: position_list, event: PositionListEvent);
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -150,10 +139,12 @@ pub mod ManagedVault {
         // The price source extension address
         // (extension, pool_id)
         price_source: (ContractAddress, felt252),
+        // The vault owner address
+        owner: ContractAddress,
         // The vault manager address
         manager: ContractAddress,
         // The Vesu singleton contract address
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         // The Ekubo core contract address
         ekubo_core: ICoreDispatcher,
         // The Multiply contract address
@@ -162,7 +153,7 @@ pub mod ManagedVault {
         redemption_timeout: u64,
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
-        redemption_requests: LegacyMap::<ContractAddress, (u64, u256, u256)>,
+        redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
         // storage for the timestamp manager component
         #[substorage(v0)]
         position_list: position_list_component::Storage,
@@ -187,22 +178,24 @@ pub mod ManagedVault {
         decimals: u8,
         asset: ContractAddress,
         is_legacy: bool,
+        owner: ContractAddress,
         manager: ContractAddress,
         singleton: ContractAddress,
         ekubo_core: ContractAddress,
         multiply: ContractAddress,
-        redemption_timeout: u64
+        redemption_timeout: u64,
     ) {
         self.erc20.initializer(name, symbol, decimals);
 
         self.asset.write(IERC20Dispatcher { contract_address: asset });
         self.scale.write(pow_10(IERC20Dispatcher { contract_address: asset }.decimals().into()));
-        IERC20Dispatcher { contract_address: asset }.approve(singleton, BoundedInt::max());
+        IERC20Dispatcher { contract_address: asset }.approve(singleton, Bounded::MAX);
         self.is_legacy.write(is_legacy);
 
+        self.owner.write(owner);
         self.manager.write(manager);
 
-        self.singleton.write(ISingletonDispatcher { contract_address: singleton });
+        self.singleton.write(ISingletonV2Dispatcher { contract_address: singleton });
         self.ekubo_core.write(ICoreDispatcher { contract_address: ekubo_core });
         self.multiply.write(IMultiplyDispatcher { contract_address: multiply });
 
@@ -215,8 +208,11 @@ pub mod ManagedVault {
             assert!(get_caller_address() == self.manager.read(), "caller-not-manager");
         }
 
+        fn assert_owner(ref self: ContractState) {
+            assert!(get_caller_address() == self.owner.read(), "caller-not-owner");
+        }
         fn transfer_asset(
-            self: @ContractState, sender: ContractAddress, to: ContractAddress, amount: u256
+            self: @ContractState, sender: ContractAddress, to: ContractAddress, amount: u256,
         ) {
             let asset = self.asset.read();
             let is_legacy = self.is_legacy.read();
@@ -242,7 +238,7 @@ pub mod ManagedVault {
             collateral_asset: ContractAddress,
             debt_asset: ContractAddress,
             collateral_shares_before: u256,
-            collateral_shares_after: u256
+            collateral_shares_after: u256,
         ) {
             if collateral_shares_before == 0 && collateral_shares_after > 0 {
                 self.position_list.push_front(Position { pool_id, collateral_asset, debt_asset });
@@ -260,14 +256,14 @@ pub mod ManagedVault {
         }
 
         fn convert_to_assets(
-            self: @ContractState, total_supply: u256, nav: u256, shares_delta: u256
+            self: @ContractState, total_supply: u256, nav: u256, shares_delta: u256,
         ) -> u256 {
             let index = self.compute_index(total_supply, nav);
             (shares_delta * index / SCALE) * self.scale.read() / SCALE
         }
 
         fn convert_to_shares(
-            self: @ContractState, total_supply: u256, nav: u256, assets_delta: u256
+            self: @ContractState, total_supply: u256, nav: u256, assets_delta: u256,
         ) -> u256 {
             let index = self.compute_index(total_supply, nav);
             (assets_delta * SCALE / self.scale.read()) * SCALE / index
@@ -292,12 +288,12 @@ pub mod ManagedVault {
     #[abi(embed_v0)]
     impl ManagedVaultImpl of IManagedVault<ContractState> {
         fn set_manager(ref self: ContractState, manager: ContractAddress) {
-            self.assert_manager();
+            self.assert_owner();
             self.manager.write(manager);
         }
 
         fn set_price_source(ref self: ContractState, extension: ContractAddress, pool_id: felt252) {
-            self.assert_manager();
+            self.assert_owner();
             self.price_source.write((extension, pool_id));
         }
 
@@ -305,20 +301,15 @@ pub mod ManagedVault {
             self.price_source.read()
         }
 
-        /// Re-approves the vToken to be spendable by the extension
-        fn approve_singleton(ref self: ContractState) {
-            self.asset.read().approve(self.singleton.read().contract_address, BoundedInt::max());
-        }
-
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {
-            self.assert_manager();
+            self.assert_owner();
             self.redemption_timeout.write(timeout);
         }
 
         fn modify_delegation(
-            ref self: ContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool
+            ref self: ContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
         ) {
-            self.assert_manager();
+            self.assert_owner();
             self.singleton.read().modify_delegation(pool_id, delegatee, delegation);
         }
 
@@ -329,6 +320,7 @@ pub mod ManagedVault {
             proof: Span<felt252>,
         ) {
             self.assert_manager();
+            // TODO What if the interface changes?
             IMerkleDistributorDispatcher { contract_address: rewards_contract }
                 .claim(claim.amount, proof);
         }
@@ -336,6 +328,7 @@ pub mod ManagedVault {
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
             assert!(limit_amount > 0, "invalid-limit-amount");
+            // TODO Protect with an oracle enforced min slippage
             call_core_with_callback(self.ekubo_core.read(), @SwapParams { swap, limit_amount })
         }
 
@@ -345,7 +338,7 @@ pub mod ManagedVault {
             collateral_asset: ContractAddress,
             debt_asset: ContractAddress,
             collateral: Amount,
-            debt: Amount
+            debt: Amount,
         ) -> UpdatePositionResponse {
             self.assert_manager();
             let singleton = self.singleton.read();
@@ -362,8 +355,8 @@ pub mod ManagedVault {
                         user: get_contract_address(),
                         collateral: collateral,
                         debt: debt,
-                        data: array![].span()
-                    }
+                        data: array![].span(),
+                    },
                 );
 
             let (position_after, _, _) = singleton
@@ -375,14 +368,14 @@ pub mod ManagedVault {
                     collateral_asset,
                     debt_asset,
                     position_before.collateral_shares,
-                    position_after.collateral_shares
+                    position_after.collateral_shares,
                 );
 
             response
         }
 
         fn modify_lever(
-            ref self: ContractState, modify_lever_params: ModifyLeverParams
+            ref self: ContractState, modify_lever_params: ModifyLeverParams,
         ) -> ModifyLeverResponse {
             self.assert_manager();
             let singleton = self.singleton.read();
@@ -393,14 +386,14 @@ pub mod ManagedVault {
                     params.pool_id,
                     params.collateral_asset,
                     params.debt_asset,
-                    params.lever_swap_limit_amount
+                    params.lever_swap_limit_amount,
                 ),
                 ModifyLeverAction::DecreaseLever(params) => (
                     params.pool_id,
                     params.collateral_asset,
                     params.debt_asset,
-                    params.lever_swap_limit_amount
-                )
+                    params.lever_swap_limit_amount,
+                ),
             };
 
             assert!(lever_swap_limit_amount > 0, "invalid-lever-swap-limit-amount");
@@ -420,7 +413,7 @@ pub mod ManagedVault {
                     collateral_asset,
                     debt_asset,
                     position_before.collateral_shares,
-                    position_after.collateral_shares
+                    position_after.collateral_shares,
                 );
 
             response
@@ -438,12 +431,12 @@ pub mod ManagedVault {
                 let context = singleton
                     .context(pool_id, collateral_asset, debt_asset, get_contract_address());
                 let (_, collateral_value, _, debt_value) = calculate_collateral_and_debt_value(
-                    context, context.position
+                    context, context.position,
                 );
                 assets += collateral_value;
                 liabilities += debt_value;
                 position = self.position_list.next(position);
-            };
+            }
 
             let balance = if self.is_legacy.read() {
                 self.asset.read().balanceOf(get_contract_address())
@@ -480,7 +473,7 @@ pub mod ManagedVault {
         }
 
         fn redeem(
-            ref self: ContractState, receiver: ContractAddress, owner: ContractAddress
+            ref self: ContractState, receiver: ContractAddress, owner: ContractAddress,
         ) -> u256 {
             let (timestamp, shares, nav_per_share_at_request) = self
                 .redemption_requests
@@ -488,7 +481,7 @@ pub mod ManagedVault {
 
             assert!(
                 timestamp + self.redemption_timeout.read() >= get_block_timestamp(),
-                "redeem-timeout"
+                "redeem-timeout",
             );
 
             let mut per_share_nav = self.compute_index(self.erc20.total_supply(), self.nav());

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -44,6 +44,7 @@ pub trait IManagedVault<TContractState> {
     fn modify_delegation(
         ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
     );
+    fn approve_singleton(ref self: TContractState);
 
     // Management functions
     fn claim_rewards(
@@ -299,6 +300,11 @@ pub mod ManagedVault {
 
         fn price_source(self: @ContractState) -> (ContractAddress, felt252) {
             self.price_source.read()
+        }
+
+        /// Re-approves the vToken to be spendable by the extension
+        fn approve_singleton(ref self: ContractState) {
+            self.asset.read().approve(self.singleton.read().contract_address, Bounded::MAX);
         }
 
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {

--- a/src/multiply.cairo
+++ b/src/multiply.cairo
@@ -1,23 +1,23 @@
-use starknet::{ContractAddress};
-use vesu::common::{i257, i257_new};
-use vesu_periphery::swap::{Swap};
+use alexandria_math::i257::i257;
+use starknet::ContractAddress;
+use vesu_periphery::swap::Swap;
 
 #[derive(Serde, Drop, Clone)]
 pub enum ModifyLeverAction {
     IncreaseLever: IncreaseLeverParams,
-    DecreaseLever: DecreaseLeverParams
+    DecreaseLever: DecreaseLeverParams,
 }
 
 #[derive(Serde, Drop, Clone)]
 pub struct ModifyLeverParams {
-    pub action: ModifyLeverAction
+    pub action: ModifyLeverAction,
 }
 
 #[derive(Serde, Drop, Clone)]
 pub struct ModifyLeverResponse {
     pub collateral_delta: i257,
     pub debt_delta: i257,
-    pub margin_delta: i257
+    pub margin_delta: i257,
 }
 
 #[derive(Serde, Drop, Clone)]
@@ -30,7 +30,7 @@ pub struct IncreaseLeverParams {
     pub margin_swap: Array<Swap>,
     pub margin_swap_limit_amount: u128,
     pub lever_swap: Array<Swap>,
-    pub lever_swap_limit_amount: u128
+    pub lever_swap_limit_amount: u128,
 }
 
 #[derive(Serde, Drop, Clone)]
@@ -47,51 +47,41 @@ pub struct DecreaseLeverParams {
     pub withdraw_swap: Array<Swap>,
     pub withdraw_swap_limit_amount: u128,
     pub withdraw_swap_weights: Array<u128>,
-    pub close_position: bool
+    pub close_position: bool,
 }
 
 #[starknet::interface]
 pub trait IMultiply<TContractState> {
     fn modify_lever(
-        ref self: TContractState, modify_lever_params: ModifyLeverParams
+        ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
 }
 
 #[starknet::contract]
 pub mod Multiply {
-    use starknet::{ContractAddress, get_contract_address, get_caller_address};
-
-    use ekubo::{
-        components::{shared_locker::{consume_callback_data, handle_delta, call_core_with_callback}},
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129, i129Trait, i129_new}, delta::{Delta}, keys::{PoolKey}}
+    use alexandria_math::i257::I257Trait;
+    use ekubo::components::shared_locker::{
+        call_core_with_callback, consume_callback_data, handle_delta,
     };
-
-    use vesu::{
-        singleton::{ISingleton, ISingletonDispatcher, ISingletonDispatcherTrait},
-        data_model::{
-            ModifyPositionParams, Amount, AmountType, AmountDenomination, UpdatePositionResponse
-        },
-        common::{i257, i257_new}, units::{SCALE, SCALE_128}
+    use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use vesu::data_model::{
+        Amount, AmountDenomination, AmountType, ModifyPositionParams, UpdatePositionResponse,
     };
-
-    use vesu_periphery::swap::{
-        Swap, TokenAmount, RouteNode, swap, apply_weights, assert_empty_token_amounts,
-        assert_matching_token_amounts
-    };
-
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu_periphery::swap::{TokenAmount, apply_weights, assert_empty_token_amounts, swap};
+    use crate::i129_new;
     use super::{
-        IMultiply, ModifyLeverParams, ModifyLeverAction, IncreaseLeverParams, DecreaseLeverParams,
-        ModifyLeverResponse
+        DecreaseLeverParams, IMultiply, IncreaseLeverParams, ModifyLeverAction, ModifyLeverParams,
+        ModifyLeverResponse,
     };
 
     #[storage]
     struct Storage {
         core: ICoreDispatcher,
-        singleton: ISingletonDispatcher
+        singleton: ISingletonV2Dispatcher,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -106,7 +96,7 @@ pub mod Multiply {
         user: ContractAddress,
         margin: u256,
         collateral_delta: u256,
-        debt_delta: u256
+        debt_delta: u256,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -121,19 +111,19 @@ pub mod Multiply {
         user: ContractAddress,
         margin: u256,
         collateral_delta: u256,
-        debt_delta: u256
+        debt_delta: u256,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         IncreaseLever: IncreaseLever,
-        DecreaseLever: DecreaseLever
+        DecreaseLever: DecreaseLever,
     }
 
     #[constructor]
     fn constructor(
-        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonDispatcher
+        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonV2Dispatcher,
     ) {
         self.core.write(core);
         self.singleton.write(singleton);
@@ -142,38 +132,39 @@ pub mod Multiply {
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
         fn increase_lever(
-            ref self: ContractState, increase_lever_params: IncreaseLeverParams
+            ref self: ContractState, increase_lever_params: IncreaseLeverParams,
         ) -> ModifyLeverResponse {
             let core = self.core.read();
 
-            let IncreaseLeverParams { pool_id,
-            collateral_asset,
-            debt_asset,
-            user,
-            add_margin,
-            margin_swap,
-            margin_swap_limit_amount,
-            lever_swap,
-            lever_swap_limit_amount } =
-                increase_lever_params;
+            let IncreaseLeverParams {
+                pool_id,
+                collateral_asset,
+                debt_asset,
+                user,
+                add_margin,
+                margin_swap,
+                margin_swap_limit_amount,
+                lever_swap,
+                lever_swap_limit_amount,
+            } = increase_lever_params;
 
             // - swap margin asset to collateral asset (1.)
             let margin_amount = if margin_swap.len() != 0 {
                 let (margin_amount_, collateral_amount_) = swap(
-                    core, margin_swap.clone(), margin_swap_limit_amount
+                    core, margin_swap.clone(), margin_swap_limit_amount,
                 );
                 assert!(
                     add_margin == 0 && collateral_amount_.token == collateral_asset,
-                    "invalid-margin-swap-assets"
+                    "invalid-margin-swap-assets",
                 );
 
                 // - transfer margin to multiplier
                 assert!(
                     IERC20Dispatcher { contract_address: margin_amount_.token }
                         .transferFrom(
-                            user, get_contract_address(), margin_amount_.amount.mag.into()
+                            user, get_contract_address(), margin_amount_.amount.mag.into(),
                         ),
-                    "transfer-from-failed"
+                    "transfer-from-failed",
                 );
 
                 // - handleDelta for both (1.)
@@ -181,13 +172,13 @@ pub mod Multiply {
                     core,
                     margin_amount_.token,
                     i129_new(margin_amount_.amount.mag, false),
-                    get_contract_address()
+                    get_contract_address(),
                 );
                 handle_delta(
                     core,
                     collateral_asset,
                     i129_new(collateral_amount_.amount.mag, true),
-                    get_contract_address()
+                    get_contract_address(),
                 );
 
                 collateral_amount_.amount.mag
@@ -196,7 +187,7 @@ pub mod Multiply {
                 assert!(
                     IERC20Dispatcher { contract_address: collateral_asset }
                         .transferFrom(user, get_contract_address(), add_margin.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
 
                 add_margin
@@ -204,23 +195,25 @@ pub mod Multiply {
 
             // - swap debt asset to collateral asset (2.)
             // for borrowing an exact amount of debt
-            //   - input token: debt asset and output token: collateral asset, since we specify a positive input amount
+            //   - input token: debt asset and output token: collateral asset, since we specify a
+            //   positive input amount
             //     of the debt asset
             // for depositing an exact amount of collateral:
-            //   - input token: collateral asset and output token: debt asset, since we specify a negative input amount
+            //   - input token: collateral asset and output token: debt asset, since we specify a
+            //   negative input amount
             //     of the collateral asset (swap direction is reversed)
             let (debt_amount, collateral_amount) = if lever_swap.len() != 0 {
                 swap(core, lever_swap.clone(), lever_swap_limit_amount)
             } else {
                 (
                     TokenAmount { token: debt_asset, amount: i129_new(0, true) },
-                    TokenAmount { token: collateral_asset, amount: i129_new(0, false) }
+                    TokenAmount { token: collateral_asset, amount: i129_new(0, false) },
                 )
             };
 
             assert!(
                 debt_amount.token == debt_asset && collateral_amount.token == collateral_asset,
-                "invalid-lever-swap-assets"
+                "invalid-lever-swap-assets",
             );
 
             // - handleDelta (2.): withdraw collateral asset
@@ -228,7 +221,7 @@ pub mod Multiply {
                 core,
                 collateral_amount.token,
                 i129_new(collateral_amount.amount.mag, true),
-                get_contract_address()
+                get_contract_address(),
             );
 
             let singleton = self.singleton.read();
@@ -237,41 +230,44 @@ pub mod Multiply {
                 IERC20Dispatcher { contract_address: collateral_asset }
                     .approve(
                         singleton.contract_address,
-                        (collateral_amount.amount.mag + margin_amount).into()
+                        (collateral_amount.amount.mag + margin_amount).into(),
                     ),
-                "approve-failed"
+                "approve-failed",
             );
 
             // - deposit collateral asset and draw borrow asset
-            let UpdatePositionResponse { collateral_delta, debt_delta, .. } = singleton
-                .modify_position(
-                    ModifyPositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        collateral: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(
-                                (collateral_amount.amount.mag + margin_amount).into(), false
-                            )
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, ..,
+            } =
+                singleton
+                    .modify_position(
+                        ModifyPositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            collateral: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(
+                                    (collateral_amount.amount.mag + margin_amount).into(), false,
+                                ),
+                            },
+                            debt: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(debt_amount.amount.mag.into(), false),
+                            },
+                            data: ArrayTrait::new().span(),
                         },
-                        debt: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(debt_amount.amount.mag.into(), false)
-                        },
-                        data: ArrayTrait::new().span()
-                    }
-                );
+                    );
 
             // - handleDelta (2.): settle borrow asset
             handle_delta(
                 core,
                 debt_amount.token,
                 i129_new(debt_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
 
             self
@@ -282,35 +278,36 @@ pub mod Multiply {
                         debt_asset,
                         user,
                         margin: margin_amount.into(),
-                        collateral_delta: collateral_delta.abs,
-                        debt_delta: debt_delta.abs
-                    }
+                        collateral_delta: collateral_delta.abs(),
+                        debt_delta: debt_delta.abs(),
+                    },
                 );
 
             return ModifyLeverResponse {
                 collateral_delta: collateral_delta,
                 debt_delta: debt_delta,
-                margin_delta: i257_new(margin_amount.into(), false)
+                margin_delta: I257Trait::new(margin_amount.into(), false),
             };
         }
 
         fn decrease_lever(
-            ref self: ContractState, decrease_lever_params: DecreaseLeverParams
+            ref self: ContractState, decrease_lever_params: DecreaseLeverParams,
         ) -> ModifyLeverResponse {
-            let DecreaseLeverParams { pool_id,
-            collateral_asset,
-            debt_asset,
-            user,
-            mut sub_margin,
-            recipient,
-            mut lever_swap,
-            lever_swap_limit_amount,
-            lever_swap_weights,
-            mut withdraw_swap,
-            withdraw_swap_limit_amount,
-            withdraw_swap_weights,
-            close_position } =
-                decrease_lever_params;
+            let DecreaseLeverParams {
+                pool_id,
+                collateral_asset,
+                debt_asset,
+                user,
+                mut sub_margin,
+                recipient,
+                mut lever_swap,
+                lever_swap_limit_amount,
+                lever_swap_weights,
+                mut withdraw_swap,
+                withdraw_swap_limit_amount,
+                withdraw_swap_weights,
+                close_position,
+            } = decrease_lever_params;
 
             let core = self.core.read();
 
@@ -323,30 +320,32 @@ pub mod Multiply {
                 // apply weights to lever_swap token amounts
                 lever_swap =
                     apply_weights(
-                        lever_swap, lever_swap_weights, i129_new(debt.try_into().unwrap(), true)
+                        lever_swap, lever_swap_weights, i129_new(debt.try_into().unwrap(), true),
                     );
                 assert!(sub_margin == 0, "invalid-sub-margin-for-close-position");
             }
 
             // - swap collateral asset to debt asset (1.)
             // for withdrawing an exact amount of collateral:
-            //   - input token: collateral asset and output token: debt asset, since we specify a positive input amount
+            //   - input token: collateral asset and output token: debt asset, since we specify a
+            //   positive input amount
             //     of the collateral asset
             // for repaying an exact amount of debt:
-            //   - input token: debt asset and output token: collateral asset, since we specify a negative input amount
+            //   - input token: debt asset and output token: collateral asset, since we specify a
+            //   negative input amount
             //     of the debt asset (swap direction is reversed)
             let (collateral_amount, debt_amount) = if lever_swap.len() != 0 {
                 swap(core, lever_swap.clone(), lever_swap_limit_amount)
             } else {
                 (
                     TokenAmount { token: collateral_asset, amount: i129_new(0, true) },
-                    TokenAmount { token: debt_asset, amount: i129_new(0, false) }
+                    TokenAmount { token: debt_asset, amount: i129_new(0, false) },
                 )
             };
 
             assert!(
                 collateral_amount.token == collateral_asset && debt_amount.token == debt_asset,
-                "invalid-lever-swap-assets"
+                "invalid-lever-swap-assets",
             );
 
             // - handleDelta: withdraw debt asset (1.)
@@ -354,7 +353,7 @@ pub mod Multiply {
                 self.core.read(),
                 debt_amount.token,
                 i129_new(debt_amount.amount.mag, true),
-                get_contract_address()
+                get_contract_address(),
             );
 
             let singleton = self.singleton.read();
@@ -362,62 +361,65 @@ pub mod Multiply {
             assert!(
                 IERC20Dispatcher { contract_address: debt_asset }
                     .approve(singleton.contract_address, debt_amount.amount.mag.into()),
-                "approve-failed"
+                "approve-failed",
             );
 
             // - withdraw collateral asset and repay borrow asset
-            let UpdatePositionResponse { collateral_delta, debt_delta, .. } = self
-                .singleton
-                .read()
-                .modify_position(
-                    ModifyPositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        collateral: if close_position {
-                            Amount {
-                                amount_type: AmountType::Target,
-                                denomination: AmountDenomination::Native,
-                                value: i257_new(0, false)
-                            }
-                        } else {
-                            Amount {
-                                amount_type: AmountType::Delta,
-                                denomination: AmountDenomination::Assets,
-                                value: i257_new(
-                                    (collateral_amount.amount.mag + sub_margin).into(), true
-                                )
-                            }
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, ..,
+            } =
+                self
+                    .singleton
+                    .read()
+                    .modify_position(
+                        ModifyPositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            collateral: if close_position {
+                                Amount {
+                                    amount_type: AmountType::Target,
+                                    denomination: AmountDenomination::Native,
+                                    value: I257Trait::new(0, false),
+                                }
+                            } else {
+                                Amount {
+                                    amount_type: AmountType::Delta,
+                                    denomination: AmountDenomination::Assets,
+                                    value: I257Trait::new(
+                                        (collateral_amount.amount.mag + sub_margin).into(), true,
+                                    ),
+                                }
+                            },
+                            debt: if close_position {
+                                Amount {
+                                    amount_type: AmountType::Target,
+                                    denomination: AmountDenomination::Native,
+                                    value: I257Trait::new(0, false),
+                                }
+                            } else {
+                                Amount {
+                                    amount_type: AmountType::Delta,
+                                    denomination: AmountDenomination::Assets,
+                                    value: I257Trait::new(debt_amount.amount.mag.into(), true),
+                                }
+                            },
+                            data: ArrayTrait::new().span(),
                         },
-                        debt: if close_position {
-                            Amount {
-                                amount_type: AmountType::Target,
-                                denomination: AmountDenomination::Native,
-                                value: i257_new(0, false)
-                            }
-                        } else {
-                            Amount {
-                                amount_type: AmountType::Delta,
-                                denomination: AmountDenomination::Assets,
-                                value: i257_new(debt_amount.amount.mag.into(), true)
-                            }
-                        },
-                        data: ArrayTrait::new().span()
-                    }
-                );
+                    );
 
-            assert!(debt_amount.amount.mag.into() == debt_delta.abs, "excess-debt-repayment");
+            assert!(debt_amount.amount.mag.into() == debt_delta.abs(), "excess-debt-repayment");
 
             // - handleDelta: settle collateral asset (1.)
             handle_delta(
                 self.core.read(),
                 collateral_amount.token,
                 i129_new(collateral_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
 
-            let residual_collateral = collateral_delta.abs.try_into().unwrap()
+            let residual_collateral = collateral_delta.abs().try_into().unwrap()
                 - collateral_amount.amount.mag;
 
             self
@@ -428,9 +430,9 @@ pub mod Multiply {
                         debt_asset,
                         user,
                         margin: sub_margin.into(),
-                        collateral_delta: collateral_delta.abs,
-                        debt_delta: debt_delta.abs
-                    }
+                        collateral_delta: collateral_delta.abs(),
+                        debt_delta: debt_delta.abs(),
+                    },
                 );
 
             // avoid withdraw_swap moving error by returning early here
@@ -438,12 +440,12 @@ pub mod Multiply {
                 assert!(
                     IERC20Dispatcher { contract_address: collateral_asset }
                         .transfer(recipient, residual_collateral.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
                 return ModifyLeverResponse {
                     collateral_delta: collateral_delta,
                     debt_delta: debt_delta,
-                    margin_delta: i257_new(residual_collateral.into(), true)
+                    margin_delta: I257Trait::new(residual_collateral.into(), true),
                 };
             }
 
@@ -453,29 +455,32 @@ pub mod Multiply {
             // apply weights to withdraw_swap token amounts
             withdraw_swap =
                 apply_weights(
-                    withdraw_swap, withdraw_swap_weights, i129_new(residual_collateral, true)
+                    withdraw_swap, withdraw_swap_weights, i129_new(residual_collateral, true),
                 );
 
             // collateral_asset to arbitrary_asset
             // token_amount is always positive, limit_amount is min. amount out:
             let (collateral_margin_amount, out_amount) = swap(
-                core, withdraw_swap.clone(), withdraw_swap_limit_amount
+                core, withdraw_swap.clone(), withdraw_swap_limit_amount,
             );
 
             handle_delta(
                 self.core.read(),
                 collateral_margin_amount.token,
                 i129_new(collateral_margin_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
             handle_delta(
-                self.core.read(), out_amount.token, i129_new(out_amount.amount.mag, true), recipient
+                self.core.read(),
+                out_amount.token,
+                i129_new(out_amount.amount.mag, true),
+                recipient,
             );
 
             return ModifyLeverResponse {
                 collateral_delta: collateral_delta,
                 debt_delta: debt_delta,
-                margin_delta: i257_new(out_amount.amount.mag.into(), true)
+                margin_delta: I257Trait::new(out_amount.amount.mag.into(), true),
             };
         }
     }
@@ -489,7 +494,7 @@ pub mod Multiply {
             let modify_lever_params: ModifyLeverParams = consume_callback_data(core, data);
             let modify_lever_response = match modify_lever_params.action {
                 ModifyLeverAction::IncreaseLever(params) => self.increase_lever(params),
-                ModifyLeverAction::DecreaseLever(params) => self.decrease_lever(params)
+                ModifyLeverAction::DecreaseLever(params) => self.decrease_lever(params),
             };
 
             let mut data: Array<felt252> = array![];
@@ -501,11 +506,11 @@ pub mod Multiply {
     #[abi(embed_v0)]
     impl MultiplyImpl of IMultiply<ContractState> {
         fn modify_lever(
-            ref self: ContractState, modify_lever_params: ModifyLeverParams
+            ref self: ContractState, modify_lever_params: ModifyLeverParams,
         ) -> ModifyLeverResponse {
             let user = match modify_lever_params.clone().action {
                 ModifyLeverAction::IncreaseLever(params) => params.user,
-                ModifyLeverAction::DecreaseLever(params) => params.user
+                ModifyLeverAction::DecreaseLever(params) => params.user,
             };
             assert!(user == get_caller_address(), "caller-not-user");
             call_core_with_callback(self.core.read(), @modify_lever_params)

--- a/src/multiply4626.cairo
+++ b/src/multiply4626.cairo
@@ -1,6 +1,6 @@
+use alexandria_math::i257::i257;
 use starknet::ContractAddress;
-use vesu::common::{i257, i257_new};
-use vesu_periphery::swap::{Swap};
+use vesu_periphery::swap::Swap;
 
 #[starknet::interface]
 pub trait I4626<TContractState> {
@@ -10,19 +10,19 @@ pub trait I4626<TContractState> {
 
 #[derive(Serde, Drop, Clone)]
 pub enum ModifyLeverAction {
-    IncreaseLever: IncreaseLeverParams
+    IncreaseLever: IncreaseLeverParams,
 }
 
 #[derive(Serde, Drop, Clone)]
 pub struct ModifyLeverParams {
-    pub action: ModifyLeverAction
+    pub action: ModifyLeverAction,
 }
 
 #[derive(Serde, Drop, Clone)]
 pub struct ModifyLeverResponse {
     pub collateral_delta: i257,
     pub debt_delta: i257,
-    pub margin_delta: i257
+    pub margin_delta: i257,
 }
 
 #[derive(Serde, Drop, Clone)]
@@ -40,45 +40,35 @@ pub struct IncreaseLeverParams {
 #[starknet::interface]
 pub trait IMultiply4626<TContractState> {
     fn modify_lever(
-        ref self: TContractState, modify_lever_params: ModifyLeverParams
+        ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
 }
 
 #[starknet::contract]
 pub mod Multiply4626 {
-    use starknet::{ContractAddress, get_contract_address, get_caller_address};
-
-    use ekubo::{
-        components::{shared_locker::{consume_callback_data, handle_delta, call_core_with_callback}},
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129, i129Trait, i129_new}, delta::{Delta}, keys::{PoolKey}}
+    use alexandria_math::i257::I257Trait;
+    use ekubo::components::shared_locker::{
+        call_core_with_callback, consume_callback_data, handle_delta,
     };
-
-    use vesu::{
-        singleton::{ISingleton, ISingletonDispatcher, ISingletonDispatcherTrait},
-        data_model::{
-            ModifyPositionParams, Amount, AmountType, AmountDenomination, UpdatePositionResponse
-        },
-        common::{i257, i257_new}, units::{SCALE, SCALE_128}
+    use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use vesu::data_model::{
+        Amount, AmountDenomination, AmountType, ModifyPositionParams, UpdatePositionResponse,
     };
-
-    use vesu_periphery::swap::{
-        Swap, TokenAmount, RouteNode, swap, apply_weights, assert_empty_token_amounts,
-        assert_matching_token_amounts
-    };
-
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu_periphery::swap::swap;
+    use crate::i129_new;
     use super::{
-        IMultiply4626, ModifyLeverParams, ModifyLeverAction, IncreaseLeverParams,
-        ModifyLeverResponse, I4626Dispatcher, I4626DispatcherTrait
+        I4626Dispatcher, I4626DispatcherTrait, IMultiply4626, IncreaseLeverParams,
+        ModifyLeverAction, ModifyLeverParams, ModifyLeverResponse,
     };
 
     #[storage]
     struct Storage {
         core: ICoreDispatcher,
-        singleton: ISingletonDispatcher
+        singleton: ISingletonV2Dispatcher,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -93,18 +83,18 @@ pub mod Multiply4626 {
         user: ContractAddress,
         margin: u256,
         collateral_delta: u256,
-        debt_delta: u256
+        debt_delta: u256,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        IncreaseLever: IncreaseLever
+        IncreaseLever: IncreaseLever,
     }
 
     #[constructor]
     fn constructor(
-        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonDispatcher
+        ref self: ContractState, core: ICoreDispatcher, singleton: ISingletonV2Dispatcher,
     ) {
         self.core.write(core);
         self.singleton.write(singleton);
@@ -113,39 +103,40 @@ pub mod Multiply4626 {
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
         fn increase_lever(
-            ref self: ContractState, increase_lever_params: IncreaseLeverParams
+            ref self: ContractState, increase_lever_params: IncreaseLeverParams,
         ) -> ModifyLeverResponse {
             let core = self.core.read();
 
-            let IncreaseLeverParams { pool_id,
-            collateral_asset,
-            user,
-            add_margin,
-            add_margin_is_wrapped,
-            margin_swap,
-            margin_swap_limit_amount,
-            lever_amount } =
-                increase_lever_params;
+            let IncreaseLeverParams {
+                pool_id,
+                collateral_asset,
+                user,
+                add_margin,
+                add_margin_is_wrapped,
+                margin_swap,
+                margin_swap_limit_amount,
+                lever_amount,
+            } = increase_lever_params;
 
             let debt_asset = I4626Dispatcher { contract_address: collateral_asset }.asset();
 
             // - swap margin asset to debt asset (1.)
             let margin_amount = if margin_swap.len() != 0 {
                 let (margin_amount_, debt_amount_) = swap(
-                    core, margin_swap.clone(), margin_swap_limit_amount
+                    core, margin_swap.clone(), margin_swap_limit_amount,
                 );
                 assert!(
                     add_margin == 0 && debt_amount_.token == debt_asset,
-                    "invalid-margin-swap-assets"
+                    "invalid-margin-swap-assets",
                 );
 
                 // - transfer margin to multiplier
                 assert!(
                     IERC20Dispatcher { contract_address: margin_amount_.token }
                         .transferFrom(
-                            user, get_contract_address(), margin_amount_.amount.mag.into()
+                            user, get_contract_address(), margin_amount_.amount.mag.into(),
                         ),
-                    "transfer-from-failed"
+                    "transfer-from-failed",
                 );
 
                 // - handleDelta for both (1.)
@@ -153,13 +144,13 @@ pub mod Multiply4626 {
                     core,
                     margin_amount_.token,
                     i129_new(margin_amount_.amount.mag, false),
-                    get_contract_address()
+                    get_contract_address(),
                 );
                 handle_delta(
                     core,
                     debt_asset,
                     i129_new(debt_amount_.amount.mag, true),
-                    get_contract_address()
+                    get_contract_address(),
                 );
 
                 debt_amount_.amount.mag
@@ -171,10 +162,10 @@ pub mod Multiply4626 {
                             collateral_asset
                         } else {
                             debt_asset
-                        }
+                        },
                     }
                         .transferFrom(user, get_contract_address(), add_margin.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
 
                 add_margin
@@ -194,7 +185,7 @@ pub mod Multiply4626 {
                     } else {
                         (margin_amount + lever_amount).into()
                     },
-                    get_contract_address()
+                    get_contract_address(),
                 );
 
             if add_margin_is_wrapped {
@@ -206,32 +197,35 @@ pub mod Multiply4626 {
             assert!(
                 IERC20Dispatcher { contract_address: collateral_asset }
                     .approve(singleton.contract_address, wrapped_amount.into()),
-                "approve-failed"
+                "approve-failed",
             );
 
             // - deposit collateral asset and draw borrow asset
-            let UpdatePositionResponse { collateral_delta, debt_delta, .. } = singleton
-                .modify_position(
-                    ModifyPositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        collateral: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(wrapped_amount.into(), false)
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, ..,
+            } =
+                singleton
+                    .modify_position(
+                        ModifyPositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            collateral: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(wrapped_amount.into(), false),
+                            },
+                            debt: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(lever_amount.into(), false),
+                            },
+                            data: ArrayTrait::new().span(),
                         },
-                        debt: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(lever_amount.into(), false)
-                        },
-                        data: ArrayTrait::new().span()
-                    }
-                );
+                    );
 
-            assert!(lever_amount.into() == debt_delta.abs, "invalid-debt-delta");
+            assert!(lever_amount.into() == debt_delta.abs(), "invalid-debt-delta");
 
             handle_delta(core, debt_asset, i129_new(lever_amount, false), get_contract_address());
 
@@ -243,15 +237,15 @@ pub mod Multiply4626 {
                         debt_asset,
                         user,
                         margin: margin_amount.into(),
-                        collateral_delta: collateral_delta.abs,
-                        debt_delta: debt_delta.abs
-                    }
+                        collateral_delta: collateral_delta.abs(),
+                        debt_delta: debt_delta.abs(),
+                    },
                 );
 
             return ModifyLeverResponse {
                 collateral_delta: collateral_delta,
                 debt_delta: debt_delta,
-                margin_delta: i257_new(margin_amount.into(), false)
+                margin_delta: I257Trait::new(margin_amount.into(), false),
             };
         }
     }
@@ -264,7 +258,7 @@ pub mod Multiply4626 {
             // asserts that caller is core
             let modify_lever_params: ModifyLeverParams = consume_callback_data(core, data);
             let modify_lever_response = match modify_lever_params.action {
-                ModifyLeverAction::IncreaseLever(params) => self.increase_lever(params)
+                ModifyLeverAction::IncreaseLever(params) => self.increase_lever(params),
             };
 
             let mut data: Array<felt252> = array![];
@@ -276,10 +270,10 @@ pub mod Multiply4626 {
     #[abi(embed_v0)]
     impl Multiply4626Impl of IMultiply4626<ContractState> {
         fn modify_lever(
-            ref self: ContractState, modify_lever_params: ModifyLeverParams
+            ref self: ContractState, modify_lever_params: ModifyLeverParams,
         ) -> ModifyLeverResponse {
             let user = match modify_lever_params.clone().action {
-                ModifyLeverAction::IncreaseLever(params) => params.user
+                ModifyLeverAction::IncreaseLever(params) => params.user,
             };
             assert!(user == get_caller_address(), "caller-not-user");
             call_core_with_callback(self.core.read(), @modify_lever_params)

--- a/src/proxy.cairo
+++ b/src/proxy.cairo
@@ -1,4 +1,5 @@
-use starknet::{account::Call, ContractAddress};
+use starknet::ContractAddress;
+use starknet::account::Call;
 
 #[generate_trait]
 impl ArrayExt<T, +Drop<T>, +Copy<T>> of ArrayExtTrait<T> {
@@ -13,14 +14,14 @@ impl ArrayExt<T, +Drop<T>, +Copy<T>> of ArrayExtTrait<T> {
 pub trait IProxy<TContractState> {
     fn manager(self: @TContractState) -> ContractAddress;
     fn access_control(
-        self: @TContractState, caller: ContractAddress, contract: ContractAddress, method: felt252
+        self: @TContractState, caller: ContractAddress, contract: ContractAddress, method: felt252,
     ) -> bool;
     fn set_caller_for_method(
         ref self: TContractState,
         caller: ContractAddress,
         contract: ContractAddress,
         method: felt252,
-        can_call: bool
+        can_call: bool,
     );
     fn set_manager(ref self: TContractState, new_manager: ContractAddress);
     fn proxy_call(ref self: TContractState, calls: Span<Call>) -> Array<Span<felt252>>;
@@ -28,22 +29,25 @@ pub trait IProxy<TContractState> {
 
 #[starknet::contract]
 pub mod Proxy {
-    use starknet::{
-        account::Call, syscalls::call_contract_syscall, ContractAddress, get_caller_address
+    use starknet::account::Call;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
-    use vesu::singleton::{Singleton, ISingletonDispatcher, ISingletonDispatcherTrait};
+    use starknet::syscalls::call_contract_syscall;
+    use starknet::{ContractAddress, get_caller_address};
     use super::{ArrayExt, IProxy};
 
     #[storage]
     struct Storage {
         manager: ContractAddress,
-        access_control: LegacyMap<(ContractAddress, ContractAddress, felt252), bool>
+        access_control: Map<(ContractAddress, ContractAddress, felt252), bool>,
     }
 
     #[derive(Drop, starknet::Event)]
     struct SetManager {
         #[key]
-        manager: ContractAddress
+        manager: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -54,14 +58,14 @@ pub mod Proxy {
         contract: ContractAddress,
         #[key]
         selector: felt252,
-        can_call: bool
+        can_call: bool,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         SetManager: SetManager,
-        SetCallerForSelector: SetCallerForSelector
+        SetCallerForSelector: SetCallerForSelector,
     }
 
     #[constructor]
@@ -80,7 +84,7 @@ pub mod Proxy {
             self: @ContractState,
             caller: ContractAddress,
             contract: ContractAddress,
-            method: felt252
+            method: felt252,
         ) -> bool {
             self.access_control.read((caller, contract, method))
         }
@@ -90,15 +94,15 @@ pub mod Proxy {
             caller: ContractAddress,
             contract: ContractAddress,
             method: felt252,
-            can_call: bool
+            can_call: bool,
         ) {
             assert!(get_caller_address() == self.manager.read(), "caller-not-manager");
             self.access_control.write((caller, contract, method), can_call);
             self
                 .emit(
                     SetCallerForSelector {
-                        caller: caller, contract: contract, selector: method, can_call: can_call
-                    }
+                        caller: caller, contract: contract, selector: method, can_call: can_call,
+                    },
                 );
         }
 
@@ -111,28 +115,27 @@ pub mod Proxy {
         fn proxy_call(ref self: ContractState, mut calls: Span<Call>) -> Array<Span<felt252>> {
             let mut result = array![];
             let mut index = 0;
-            while let Option::Some(call) = calls
-                .pop_front() {
-                    assert!(
-                        get_caller_address() == self.manager.read()
-                            || self
-                                .access_control
-                                .read((get_caller_address(), *call.to, *call.selector)),
-                        "caller-not-authorized"
-                    );
+            while let Option::Some(call) = calls.pop_front() {
+                assert!(
+                    get_caller_address() == self.manager.read()
+                        || self
+                            .access_control
+                            .read((get_caller_address(), *call.to, *call.selector)),
+                    "caller-not-authorized",
+                );
 
-                    match call_contract_syscall(*call.to, *call.selector, *call.calldata) {
-                        Result::Ok(return_data) => {
-                            result.append(return_data);
-                            index += 1;
-                        },
-                        Result::Err(revert_reason) => {
-                            let mut data = array!['proxy-call-failed', index];
-                            data.append_all(revert_reason.span());
-                            panic(data);
-                        },
-                    }
-                };
+                match call_contract_syscall(*call.to, *call.selector, *call.calldata) {
+                    Result::Ok(return_data) => {
+                        result.append(return_data);
+                        index += 1;
+                    },
+                    Result::Err(revert_reason) => {
+                        let mut data = array!['proxy-call-failed', index];
+                        data.append_all(revert_reason.span());
+                        panic(data);
+                    },
+                }
+            }
             result
         }
     }

--- a/src/rebalance.cairo
+++ b/src/rebalance.cairo
@@ -1,13 +1,11 @@
-use ekubo::types::i129::{i129};
-use ekubo::types::keys::{PoolKey};
-use starknet::{ContractAddress};
-use vesu::common::{i257, i257_new};
-use vesu_periphery::swap::{Swap};
+use alexandria_math::i257::i257;
+use starknet::ContractAddress;
+use vesu_periphery::swap::Swap;
 
 #[derive(Serde, Drop, Clone)]
 pub struct RebalanceResponse {
     pub collateral_delta: i257,
-    pub debt_delta: i257
+    pub debt_delta: i257,
 }
 
 #[derive(Serde, Drop, Clone)]
@@ -18,7 +16,7 @@ pub struct RebalanceParams {
     pub user: ContractAddress,
     pub rebalance_swap: Array<Swap>,
     pub rebalance_swap_limit_amount: u128,
-    pub fee_recipient: ContractAddress
+    pub fee_recipient: ContractAddress,
 }
 
 #[starknet::interface]
@@ -34,66 +32,61 @@ pub trait IRebalance<TContractState> {
         debt_asset: ContractAddress,
         target_ltv: u128,
         target_ltv_tolerance: u128,
-        target_ltv_min_delta: u128
+        target_ltv_min_delta: u128,
     );
     fn delta(
         self: @TContractState,
         pool_id: felt252,
         collateral_asset: ContractAddress,
         debt_asset: ContractAddress,
-        user: ContractAddress
+        user: ContractAddress,
     ) -> (u256, i257, i257, i257);
     fn rebalance_position(
-        ref self: TContractState, rebalance_params: RebalanceParams
+        ref self: TContractState, rebalance_params: RebalanceParams,
     ) -> RebalanceResponse;
 }
 
 #[starknet::contract]
 pub mod Rebalance {
-    use starknet::{ContractAddress, get_contract_address, get_caller_address};
-
-    use core::num::traits::{Zero};
-
-    use ekubo::{
-        components::{shared_locker::{consume_callback_data, handle_delta, call_core_with_callback}},
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129, i129Trait, i129_new}, delta::{Delta}, keys::{PoolKey}}
+    use alexandria_math::i257::{I257Trait, i257};
+    use core::num::traits::Zero;
+    use ekubo::components::shared_locker::{
+        call_core_with_callback, consume_callback_data, handle_delta,
     };
-
-    use vesu::{
-        singleton::{ISingleton, ISingletonDispatcher, ISingletonDispatcherTrait},
-        data_model::{
-            ModifyPositionParams, Amount, AmountType, AmountDenomination, UpdatePositionResponse,
-            AssetConfig
-        },
-        extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait},
-        common::{i257, i257_new}, units::{SCALE, SCALE_128}
+    use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
-
-    use vesu_periphery::swap::{Swap, RouteNode, TokenAmount, swap};
-
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use vesu::data_model::{
+        Amount, AmountDenomination, AmountType, ModifyPositionParams, UpdatePositionResponse,
+    };
+    use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::units::{SCALE, SCALE_128};
+    use vesu_periphery::swap::swap;
+    use crate::i129_new;
     use super::{IRebalance, RebalanceParams, RebalanceResponse};
 
     #[derive(PartialEq, Copy, Drop, Serde, starknet::Store)]
     struct TargetLTVConfig {
         target_ltv: u128,
         target_ltv_tolerance: u128,
-        target_ltv_min_delta: u128
+        target_ltv_min_delta: u128,
     }
 
     #[storage]
     struct Storage {
         core: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         owner: ContractAddress,
-        rebalancers: LegacyMap::<ContractAddress, bool>,
+        rebalancers: Map<ContractAddress, bool>,
         fee_rate: u128,
         // (pool_id, collateral_asset, debt_asset, user) -> target_ltv_config
-        target_ltv_config: LegacyMap::<
-            (felt252, ContractAddress, ContractAddress, ContractAddress), TargetLTVConfig
+        target_ltv_config: Map<
+            (felt252, ContractAddress, ContractAddress, ContractAddress), TargetLTVConfig,
         >,
     }
 
@@ -102,14 +95,14 @@ pub mod Rebalance {
         #[key]
         new_owner: ContractAddress,
         #[key]
-        prev_owner: ContractAddress
+        prev_owner: ContractAddress,
     }
 
     #[derive(Drop, starknet::Event)]
     struct SetRebalancer {
         #[key]
         rebalancer: ContractAddress,
-        allowed: bool
+        allowed: bool,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -124,7 +117,7 @@ pub mod Rebalance {
         user: ContractAddress,
         target_ltv: u128,
         target_ltv_tolerance: u128,
-        target_ltv_min_delta: u128
+        target_ltv_min_delta: u128,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -140,7 +133,7 @@ pub mod Rebalance {
         old_ltv: u256,
         new_ltv: u256,
         collateral_delta: i257,
-        debt_delta: i257
+        debt_delta: i257,
     }
 
     #[event]
@@ -156,9 +149,9 @@ pub mod Rebalance {
     fn constructor(
         ref self: ContractState,
         core: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         owner: ContractAddress,
-        fee_rate: u128
+        fee_rate: u128,
     ) {
         self.core.write(core);
         self.singleton.write(singleton);
@@ -171,19 +164,19 @@ pub mod Rebalance {
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
         fn rebalance(
-            ref self: ContractState, rebalance_params: RebalanceParams
+            ref self: ContractState, rebalance_params: RebalanceParams,
         ) -> RebalanceResponse {
-            let RebalanceParams { pool_id, collateral_asset, debt_asset, user, .., } =
-                rebalance_params
-                .clone();
+            let RebalanceParams {
+                pool_id, collateral_asset, debt_asset, user, ..,
+            } = rebalance_params.clone();
 
-            let TargetLTVConfig { target_ltv, target_ltv_tolerance, target_ltv_min_delta } = self
-                .target_ltv_config
-                .read((pool_id, collateral_asset, debt_asset, user));
+            let TargetLTVConfig {
+                target_ltv, target_ltv_tolerance, target_ltv_min_delta,
+            } = self.target_ltv_config.read((pool_id, collateral_asset, debt_asset, user));
 
             let (current_ltv, delta_usd, _, _) = self
                 .delta(pool_id, collateral_asset, debt_asset, user);
-            assert!(delta_usd.abs != 0, "zero-delta");
+            assert!(delta_usd.abs() != 0, "zero-delta");
 
             let ltv_delta = if target_ltv.into() > current_ltv {
                 target_ltv.into() - current_ltv
@@ -192,7 +185,7 @@ pub mod Rebalance {
             };
             assert!(ltv_delta >= target_ltv_min_delta.into(), "target-ltv-min-delta");
 
-            let (collateral_delta, debt_delta) = if !delta_usd.is_negative {
+            let (collateral_delta, debt_delta) = if !delta_usd.is_negative() {
                 self.increase_lever(rebalance_params)
             } else {
                 self.decrease_lever(rebalance_params)
@@ -204,7 +197,7 @@ pub mod Rebalance {
                 (target_ltv < target_ltv_tolerance
                     || (target_ltv - target_ltv_tolerance).into() <= new_ltv)
                     && new_ltv <= (target_ltv + target_ltv_tolerance).into(),
-                "target-ltv-tolerance"
+                "target-ltv-tolerance",
             );
 
             self
@@ -217,8 +210,8 @@ pub mod Rebalance {
                         old_ltv: current_ltv,
                         new_ltv,
                         collateral_delta,
-                        debt_delta
-                    }
+                        debt_delta,
+                    },
                 );
 
             RebalanceResponse { collateral_delta, debt_delta }
@@ -226,34 +219,37 @@ pub mod Rebalance {
 
         /// Increase lever by swapping debt asset to collateral asset and depositing collateral
         fn increase_lever(
-            ref self: ContractState, rebalance_params: RebalanceParams
+            ref self: ContractState, rebalance_params: RebalanceParams,
         ) -> (i257, i257) {
-            let RebalanceParams { pool_id,
-            collateral_asset,
-            debt_asset,
-            user,
-            fee_recipient,
-            mut rebalance_swap,
-            rebalance_swap_limit_amount } =
-                rebalance_params;
+            let RebalanceParams {
+                pool_id,
+                collateral_asset,
+                debt_asset,
+                user,
+                fee_recipient,
+                mut rebalance_swap,
+                rebalance_swap_limit_amount,
+            } = rebalance_params;
 
             let core = self.core.read();
 
             // - swap debt asset to collateral asset (2.)
             // for borrowing an exact amount of debt
-            //   - input token: debt asset and output token: collateral asset, since we specify a positive input amount
+            //   - input token: debt asset and output token: collateral asset, since we specify a
+            //   positive input amount
             //     of the debt asset
             // for depositing an exact amount of collateral:
-            //   - input token: collateral asset and output token: debt asset, since we specify a negative input amount
+            //   - input token: collateral asset and output token: debt asset, since we specify a
+            //   negative input amount
             //     of the collateral asset (swap direction is reversed)
             assert!(rebalance_swap.len() != 0, "invalid-rebalance-swap");
             let (debt_amount, mut collateral_amount) = swap(
-                core, rebalance_swap.clone(), rebalance_swap_limit_amount
+                core, rebalance_swap.clone(), rebalance_swap_limit_amount,
             );
 
             assert!(
                 debt_amount.token == debt_asset && collateral_amount.token == collateral_asset,
-                "invalid-rebalance-swap-assets"
+                "invalid-rebalance-swap-assets",
             );
 
             // - handleDelta (2.): withdraw collateral asset
@@ -261,7 +257,7 @@ pub mod Rebalance {
                 core,
                 collateral_amount.token,
                 i129_new(collateral_amount.amount.mag, true),
-                get_contract_address()
+                get_contract_address(),
             );
 
             // charge swap fee on the collateral amount to deposit
@@ -272,7 +268,7 @@ pub mod Rebalance {
                 assert!(
                     IERC20Dispatcher { contract_address: collateral_asset }
                         .transfer(fee_recipient, fee.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
             }
 
@@ -281,37 +277,40 @@ pub mod Rebalance {
             assert!(
                 IERC20Dispatcher { contract_address: collateral_asset }
                     .approve(singleton.contract_address, collateral_amount.amount.mag.into()),
-                "approve-failed"
+                "approve-failed",
             );
 
             // - deposit collateral asset and draw borrow asset
-            let UpdatePositionResponse { collateral_delta, debt_delta, .. } = singleton
-                .modify_position(
-                    ModifyPositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        collateral: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(collateral_amount.amount.mag.into(), false)
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, ..,
+            } =
+                singleton
+                    .modify_position(
+                        ModifyPositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            collateral: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(collateral_amount.amount.mag.into(), false),
+                            },
+                            debt: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(debt_amount.amount.mag.into(), false),
+                            },
+                            data: ArrayTrait::new().span(),
                         },
-                        debt: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(debt_amount.amount.mag.into(), false)
-                        },
-                        data: ArrayTrait::new().span()
-                    }
-                );
+                    );
 
             // - handleDelta (2.): settle borrow asset
             handle_delta(
                 core,
                 debt_amount.token,
                 i129_new(debt_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
 
             (collateral_delta, debt_delta)
@@ -319,35 +318,38 @@ pub mod Rebalance {
 
         /// Decrease lever by swapping collateral asset to debt asset and repaying debt
         fn decrease_lever(
-            ref self: ContractState, rebalance_params: RebalanceParams
+            ref self: ContractState, rebalance_params: RebalanceParams,
         ) -> (i257, i257) {
-            let RebalanceParams { pool_id,
-            collateral_asset,
-            debt_asset,
-            user,
-            fee_recipient,
-            mut rebalance_swap,
-            rebalance_swap_limit_amount,
-            .. } =
-                rebalance_params;
+            let RebalanceParams {
+                pool_id,
+                collateral_asset,
+                debt_asset,
+                user,
+                fee_recipient,
+                mut rebalance_swap,
+                rebalance_swap_limit_amount,
+                ..,
+            } = rebalance_params;
 
             let core = self.core.read();
 
             // - swap collateral asset to debt asset (1.)
             // for withdrawing an exact amount of collateral:
-            //   - input token: collateral asset and output token: debt asset, since we specify a positive input amount
+            //   - input token: collateral asset and output token: debt asset, since we specify a
+            //   positive input amount
             //     of the collateral asset
             // for repaying an exact amount of debt:
-            //   - input token: debt asset and output token: collateral asset, since we specify a negative input amount
+            //   - input token: debt asset and output token: collateral asset, since we specify a
+            //   negative input amount
             //     of the debt asset (swap direction is reversed)
             assert!(rebalance_swap.len() != 0, "invalid-rebalance-swap");
             let (collateral_amount, mut debt_amount) = swap(
-                core, rebalance_swap.clone(), rebalance_swap_limit_amount
+                core, rebalance_swap.clone(), rebalance_swap_limit_amount,
             );
 
             assert!(
                 collateral_amount.token == collateral_asset && debt_amount.token == debt_asset,
-                "invalid-rebalance-swap-assets"
+                "invalid-rebalance-swap-assets",
             );
 
             // - handleDelta: withdraw debt asset (1.)
@@ -355,7 +357,7 @@ pub mod Rebalance {
                 core,
                 debt_amount.token,
                 i129_new(debt_amount.amount.mag, true),
-                get_contract_address()
+                get_contract_address(),
             );
 
             // charge swap fee on debt repayment amount
@@ -366,7 +368,7 @@ pub mod Rebalance {
                 assert!(
                     IERC20Dispatcher { contract_address: debt_asset }
                         .transfer(fee_recipient, fee.into()),
-                    "transfer-failed"
+                    "transfer-failed",
                 );
             }
 
@@ -375,45 +377,48 @@ pub mod Rebalance {
             assert!(
                 IERC20Dispatcher { contract_address: debt_asset }
                     .approve(singleton.contract_address, debt_amount.amount.mag.into()),
-                "approve-failed"
+                "approve-failed",
             );
 
             // - withdraw collateral asset and repay borrow asset
-            let UpdatePositionResponse { collateral_delta, debt_delta, .. } = self
-                .singleton
-                .read()
-                .modify_position(
-                    ModifyPositionParams {
-                        pool_id,
-                        collateral_asset,
-                        debt_asset,
-                        user,
-                        collateral: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(collateral_amount.amount.mag.into(), true)
+            let UpdatePositionResponse {
+                collateral_delta, debt_delta, ..,
+            } =
+                self
+                    .singleton
+                    .read()
+                    .modify_position(
+                        ModifyPositionParams {
+                            pool_id,
+                            collateral_asset,
+                            debt_asset,
+                            user,
+                            collateral: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(collateral_amount.amount.mag.into(), true),
+                            },
+                            debt: Amount {
+                                amount_type: AmountType::Delta,
+                                denomination: AmountDenomination::Assets,
+                                value: I257Trait::new(debt_amount.amount.mag.into(), true),
+                            },
+                            data: ArrayTrait::new().span(),
                         },
-                        debt: Amount {
-                            amount_type: AmountType::Delta,
-                            denomination: AmountDenomination::Assets,
-                            value: i257_new(debt_amount.amount.mag.into(), true)
-                        },
-                        data: ArrayTrait::new().span()
-                    }
-                );
+                    );
 
             assert!(
-                collateral_amount.amount.mag.into() == collateral_delta.abs,
-                "excess-collateral-withdrawal"
+                collateral_amount.amount.mag.into() == collateral_delta.abs(),
+                "excess-collateral-withdrawal",
             );
-            assert!(debt_amount.amount.mag.into() == debt_delta.abs, "excess-debt-repayment");
+            assert!(debt_amount.amount.mag.into() == debt_delta.abs(), "excess-debt-repayment");
 
             // - handleDelta: settle collateral asset (1.)
             handle_delta(
                 self.core.read(),
                 collateral_amount.token,
                 i129_new(collateral_amount.amount.mag, false),
-                get_contract_address()
+                get_contract_address(),
             );
 
             (collateral_delta, debt_delta)
@@ -465,7 +470,7 @@ pub mod Rebalance {
             debt_asset: ContractAddress,
             target_ltv: u128,
             target_ltv_tolerance: u128,
-            target_ltv_min_delta: u128
+            target_ltv_min_delta: u128,
         ) {
             let ltv_config = self
                 .singleton
@@ -479,7 +484,7 @@ pub mod Rebalance {
                 .target_ltv_config
                 .write(
                     (pool_id, collateral_asset, debt_asset, get_caller_address()),
-                    TargetLTVConfig { target_ltv, target_ltv_tolerance, target_ltv_min_delta }
+                    TargetLTVConfig { target_ltv, target_ltv_tolerance, target_ltv_min_delta },
                 );
 
             self
@@ -491,8 +496,8 @@ pub mod Rebalance {
                         user: get_caller_address(),
                         target_ltv,
                         target_ltv_tolerance,
-                        target_ltv_min_delta
-                    }
+                        target_ltv_min_delta,
+                    },
                 );
         }
 
@@ -501,16 +506,18 @@ pub mod Rebalance {
             pool_id: felt252,
             collateral_asset: ContractAddress,
             debt_asset: ContractAddress,
-            user: ContractAddress
+            user: ContractAddress,
         ) -> (u256, i257, i257, i257) {
             let singleton = self.singleton.read();
 
-            let TargetLTVConfig { target_ltv, .. } = self
-                .target_ltv_config
-                .read((pool_id, collateral_asset, debt_asset, user));
+            let TargetLTVConfig {
+                target_ltv, ..,
+            } = self.target_ltv_config.read((pool_id, collateral_asset, debt_asset, user));
 
             if target_ltv == 0 {
-                return (0, i257_new(0, false), i257_new(0, false), i257_new(0, false));
+                return (
+                    0, I257Trait::new(0, false), I257Trait::new(0, false), I257Trait::new(0, false),
+                );
             }
 
             let (_, collateral, debt) = singleton
@@ -526,9 +533,10 @@ pub mod Rebalance {
             let collateral_usd = (collateral * collateral_asset_price.value.into())
                 / collateral_asset_config.scale;
             let debt_usd = (debt * debt_asset_price.value.into()) / debt_asset_config.scale;
-            let delta_usd = (i257_new(debt_usd, false) * i257_new(SCALE, false)
-                - (i257_new(collateral_usd, false) * i257_new(target_ltv.into(), false)))
-                / (i257_new(target_ltv.into(), false) - i257_new(SCALE, false));
+            let delta_usd = (I257Trait::new(debt_usd, false) * I257Trait::new(SCALE, false)
+                - (I257Trait::new(collateral_usd, false)
+                    * I257Trait::new(target_ltv.into(), false)))
+                / (I257Trait::new(target_ltv.into(), false) - I257Trait::new(SCALE, false));
             let current_ltv = debt_usd * SCALE / collateral_usd;
 
             let collateral_delta = delta_usd
@@ -542,7 +550,7 @@ pub mod Rebalance {
         }
 
         fn rebalance_position(
-            ref self: ContractState, rebalance_params: RebalanceParams
+            ref self: ContractState, rebalance_params: RebalanceParams,
         ) -> RebalanceResponse {
             assert!(self.rebalancers.read(get_caller_address()), "only-rebalancer");
             call_core_with_callback(self.core.read(), @rebalance_params)

--- a/src/swap.cairo
+++ b/src/swap.cairo
@@ -1,11 +1,9 @@
-use starknet::{ContractAddress};
-
-use ekubo::{
-    interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, SwapParameters},
-    types::{i129::{i129, i129Trait, i129_new}, keys::{PoolKey}}
-};
-
+use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, SwapParameters};
+use ekubo::types::i129::{i129, i129Trait};
+use ekubo::types::keys::PoolKey;
+use starknet::ContractAddress;
 use vesu::units::{SCALE, SCALE_128};
+use crate::i129_new;
 
 #[derive(Serde, Copy, Drop)]
 pub struct RouteNode {
@@ -23,38 +21,36 @@ pub struct TokenAmount {
 #[derive(Serde, Drop, Clone)]
 pub struct Swap {
     pub route: Array<RouteNode>,
-    pub token_amount: TokenAmount
+    pub token_amount: TokenAmount,
 }
 
 pub fn assert_empty_token_amounts(mut swaps: Array<Swap>) {
-    while let Option::Some(swap) = swaps
-        .pop_front() {
-            assert!(swap.token_amount.amount.mag == 0, "invalid-swap-token-amount");
-        };
+    while let Option::Some(swap) = swaps.pop_front() {
+        assert!(swap.token_amount.amount.mag == 0, "invalid-swap-token-amount");
+    };
 }
 
 pub fn assert_matching_token_amounts(mut swaps: Array<Swap>) -> bool {
     let mut token: Option<ContractAddress> = Option::None;
     let mut is_negative: Option<bool> = Option::None;
-    while let Option::Some(swap) = swaps
-        .pop_front() {
-            if token.is_none() {
-                token = Option::Some(swap.token_amount.token);
-                is_negative = Option::Some(swap.token_amount.amount.is_negative());
-            } else {
-                assert!(
-                    token.unwrap() == swap.token_amount.token
-                        && is_negative.unwrap() == swap.token_amount.amount.is_negative(),
-                    "swap-token-amount-mismatch"
-                );
-            }
-        };
+    while let Option::Some(swap) = swaps.pop_front() {
+        if let Option::Some(token) = token {
+            assert!(
+                token == swap.token_amount.token
+                    && is_negative.unwrap() == swap.token_amount.amount.is_negative(),
+                "swap-token-amount-mismatch",
+            );
+        } else {
+            token = Option::Some(swap.token_amount.token);
+            is_negative = Option::Some(swap.token_amount.amount.is_negative());
+        }
+    }
 
     is_negative.unwrap()
 }
 
 pub fn apply_weights(
-    mut swaps: Array<Swap>, mut relative_weights: Array<u128>, total_amount: i129
+    mut swaps: Array<Swap>, mut relative_weights: Array<u128>, total_amount: i129,
 ) -> Array<Swap> {
     assert!(swaps.len() == relative_weights.len(), "swaps-relative-weights-length-mismatch");
 
@@ -62,31 +58,28 @@ pub fn apply_weights(
     let mut allocated_amount = 0_u128;
     let mut adjusted_swaps = ArrayTrait::new();
 
-    while let Option::Some(swap) = swaps
-        .pop_front() {
-            let percentage = relative_weights.pop_front().unwrap();
-            let mut amount_scaled: u256 = total_amount.mag.into() * percentage.into() / SCALE;
-            let mut amount = i129_new(
-                amount_scaled.try_into().unwrap(), total_amount.is_negative()
+    while let Option::Some(swap) = swaps.pop_front() {
+        let percentage = relative_weights.pop_front().unwrap();
+        let mut amount_scaled: u256 = total_amount.mag.into() * percentage.into() / SCALE;
+        let mut amount = i129_new(amount_scaled.try_into().unwrap(), total_amount.is_negative());
+
+        allocated_amount += amount.mag;
+        weight_sum += percentage;
+
+        // allocate residual amount to the last swap due to rounding errors
+        if swaps.len() == 0 && total_amount.mag > allocated_amount.into() {
+            let rest = total_amount.mag - allocated_amount;
+            allocated_amount += rest;
+            amount = i129_new(amount.mag + rest.into(), amount.is_negative());
+        }
+        adjusted_swaps
+            .append(
+                Swap {
+                    route: swap.route,
+                    token_amount: TokenAmount { token: swap.token_amount.token, amount: amount },
+                },
             );
-
-            allocated_amount += amount.mag;
-            weight_sum += percentage;
-
-            // allocate residual amount to the last swap due to rounding errors
-            if swaps.len() == 0 && total_amount.mag > allocated_amount.into() {
-                let rest = total_amount.mag - allocated_amount;
-                allocated_amount += rest;
-                amount = i129_new(amount.mag + rest.into(), amount.is_negative());
-            }
-            adjusted_swaps
-                .append(
-                    Swap {
-                        route: swap.route,
-                        token_amount: TokenAmount { token: swap.token_amount.token, amount: amount }
-                    }
-                );
-        };
+    }
 
     assert!(weight_sum == SCALE_128, "weight-sum-not-1");
 
@@ -94,92 +87,87 @@ pub fn apply_weights(
 }
 
 pub fn swap(
-    core: ICoreDispatcher, mut swaps: Array<Swap>, limit_amount: u128
+    core: ICoreDispatcher, mut swaps: Array<Swap>, limit_amount: u128,
 ) -> (TokenAmount, TokenAmount) {
     let is_negative = assert_matching_token_amounts(swaps.clone());
 
     let mut input_amount: Option<TokenAmount> = Option::None;
     let mut output_amount: Option<TokenAmount> = Option::None;
 
-    while let Option::Some(swap) = swaps
-        .pop_front() {
-            let mut route = swap.route;
-            let mut token_amount = swap.token_amount;
+    while let Option::Some(swap) = swaps.pop_front() {
+        let mut route = swap.route;
+        let mut token_amount = swap.token_amount;
 
-            // we track this to know how much to pay in the case of exact input and how much to pull in the case of exact output
-            let mut first_swap_amount: Option<TokenAmount> = Option::None;
+        // we track this to know how much to pay in the case of exact input and how much to pull in
+        // the case of exact output
+        let mut first_swap_amount: Option<TokenAmount> = Option::None;
 
-            while let Option::Some(node) = route
-                .pop_front() {
-                    let is_token1 = token_amount.token == node.pool_key.token1;
+        while let Option::Some(node) = route.pop_front() {
+            let is_token1 = token_amount.token == node.pool_key.token1;
 
-                    let delta = core
-                        .swap(
-                            node.pool_key,
-                            SwapParameters {
-                                amount: token_amount.amount,
-                                is_token1: is_token1,
-                                sqrt_ratio_limit: node.sqrt_ratio_limit,
-                                skip_ahead: node.skip_ahead,
-                            }
-                        );
+            let delta = core
+                .swap(
+                    node.pool_key,
+                    SwapParameters {
+                        amount: token_amount.amount,
+                        is_token1: is_token1,
+                        sqrt_ratio_limit: node.sqrt_ratio_limit,
+                        skip_ahead: node.skip_ahead,
+                    },
+                );
 
-                    if is_token1 {
-                        assert!(delta.amount1.mag == token_amount.amount.mag, "partial-swap");
-                    } else {
-                        assert!(delta.amount0.mag == token_amount.amount.mag, "partial-swap");
-                    }
-
-                    if first_swap_amount.is_none() {
-                        first_swap_amount =
-                            if is_token1 {
-                                Option::Some(
-                                    TokenAmount {
-                                        token: node.pool_key.token1, amount: delta.amount1
-                                    }
-                                )
-                            } else {
-                                Option::Some(
-                                    TokenAmount {
-                                        token: node.pool_key.token0, amount: delta.amount0
-                                    }
-                                )
-                            }
-                    }
-
-                    token_amount =
-                        if (is_token1) {
-                            TokenAmount { amount: -delta.amount0, token: node.pool_key.token0 }
-                        } else {
-                            TokenAmount { amount: -delta.amount1, token: node.pool_key.token1 }
-                        };
-                };
-
-            let first = first_swap_amount.unwrap();
-            let (input, output) = if !swap.token_amount.amount.is_negative() {
-                (first, token_amount)
+            if is_token1 {
+                assert!(delta.amount1.mag == token_amount.amount.mag, "partial-swap");
             } else {
-                (token_amount, first)
-            };
+                assert!(delta.amount0.mag == token_amount.amount.mag, "partial-swap");
+            }
 
-            match (input_amount) {
-                Option::None => { input_amount = Option::Some(input); },
-                Option::Some(mut amount) => {
-                    assert!(amount.token == input.token, "input-token-mismatch");
-                    amount.amount = amount.amount + input.amount;
-                    input_amount = Option::Some(amount);
-                }
-            };
+            if first_swap_amount.is_none() {
+                first_swap_amount =
+                    if is_token1 {
+                        Option::Some(
+                            TokenAmount { token: node.pool_key.token1, amount: delta.amount1 },
+                        )
+                    } else {
+                        Option::Some(
+                            TokenAmount { token: node.pool_key.token0, amount: delta.amount0 },
+                        )
+                    }
+            }
 
-            match (output_amount) {
-                Option::None => { output_amount = Option::Some(output); },
-                Option::Some(mut amount) => {
-                    assert!(amount.token == output.token, "output-token-mismatch");
-                    amount.amount = amount.amount + output.amount;
-                    output_amount = Option::Some(amount);
-                }
-            };
+            token_amount =
+                if (is_token1) {
+                    TokenAmount { amount: -delta.amount0, token: node.pool_key.token0 }
+                } else {
+                    TokenAmount { amount: -delta.amount1, token: node.pool_key.token1 }
+                };
+        }
+
+        let first = first_swap_amount.unwrap();
+        let (input, output) = if !swap.token_amount.amount.is_negative() {
+            (first, token_amount)
+        } else {
+            (token_amount, first)
         };
+
+        match (input_amount) {
+            Option::None => { input_amount = Option::Some(input); },
+            Option::Some(mut amount) => {
+                assert!(amount.token == input.token, "input-token-mismatch");
+                amount.amount = amount.amount + input.amount;
+                input_amount = Option::Some(amount);
+            },
+        }
+
+        match (output_amount) {
+            Option::None => { output_amount = Option::Some(output); },
+            Option::Some(mut amount) => {
+                assert!(amount.token == output.token, "output-token-mismatch");
+                amount.amount = amount.amount + output.amount;
+                output_amount = Option::Some(amount);
+            },
+        };
+    }
 
     if !is_negative {
         // exact in: limit_amount is min. amount out
@@ -187,7 +175,7 @@ pub fn swap(
     } else {
         // exact out: limit_amount is max. amount in
         assert!(input_amount.unwrap().amount.mag <= limit_amount, "limit-amount-exceeded");
-    };
+    }
 
     (input_amount.unwrap(), output_amount.unwrap())
 }

--- a/src/utils/position_list.cairo
+++ b/src/utils/position_list.cairo
@@ -1,6 +1,6 @@
-use core::num::traits::zero::Zero;
 use core::hash::LegacyHash;
-use starknet::{ContractAddress, contract_address_const};
+use core::num::traits::zero::Zero;
+use starknet::ContractAddress;
 
 #[derive(PartialEq, Copy, Drop, starknet::Store)]
 pub struct Position {
@@ -24,12 +24,10 @@ impl PositionImpl of PositionTrait {
 
 impl PositionZero of Zero<Position> {
     fn zero() -> Position {
-        Position { pool_id: 0, collateral_asset: Zero::zero(), debt_asset: Zero::zero(), }
+        Position { pool_id: 0, collateral_asset: Zero::zero(), debt_asset: Zero::zero() }
     }
     fn is_zero(self: @Position) -> bool {
-        *self.pool_id == 0
-            && *self.collateral_asset == contract_address_const::<''>()
-            && *self.debt_asset == contract_address_const::<''>()
+        *self.pool_id == 0 && self.collateral_asset.is_zero() && self.debt_asset.is_zero()
     }
     fn is_non_zero(self: @Position) -> bool {
         !self.is_zero()
@@ -49,14 +47,14 @@ impl PositionLegacyHash of LegacyHash<Position> {
 #[starknet::component]
 pub mod position_list_component {
     use core::num::traits::zero::Zero;
-
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
     use super::{Position, PositionTrait};
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         // A list of positions
         // hash(position) -> next position
-        positions: LegacyMap<felt252, Position>,
+        positions: Map<felt252, Position>,
     }
 
     #[event]
@@ -65,10 +63,11 @@ pub mod position_list_component {
 
     #[generate_trait]
     pub impl PositionListTrait<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of Trait<TContractState> {
         /// Returns true if the list contains the position
-        /// Constant computation cost if `position` is in fact in the list AND it's not the last one.
+        /// Constant computation cost if `position` is in fact in the list AND it's not the last
+        /// one.
         /// Otherwise cost increases with the list size.
         fn contains(self: @ComponentState<TContractState>, position: Position) -> bool {
             if position == Zero::zero() {
@@ -104,7 +103,8 @@ pub mod position_list_component {
             self.positions.write(Zero::zero(), position_to_add);
         }
 
-        /// Removes a position from the list. Reverts if the position is not found. Cost increases with the list size.
+        /// Removes a position from the list. Reverts if the position is not found. Cost increases
+        /// with the list size.
         fn remove(ref self: ComponentState<TContractState>, position: Position) {
             assert!(position != Zero::zero(), "cannot-remove-zero");
             // position pointer set to 0, Previous pointer set to the next in the list
@@ -143,18 +143,18 @@ pub mod position_list_component {
             while current_position != Zero::zero() {
                 positions.append(current_position);
                 current_position = self.positions.read(current_position.hash());
-            };
+            }
             positions
         }
     }
 
     #[generate_trait]
     impl Private<TContractState, +HasComponent<TContractState>> of PrivateTrait<TContractState> {
-        /// Returns the position before `position_after` or Zero if the position is the first one. 
+        /// Returns the position before `position_after` or Zero if the position is the first one.
         /// Reverts if `position_after` is not found
         /// Cost increases with the list size
         fn find_position_before(
-            self: @ComponentState<TContractState>, position_after: Position
+            self: @ComponentState<TContractState>, position_after: Position,
         ) -> Position {
             let mut current_position: Position = Zero::zero();
             loop {

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -46,7 +46,7 @@ mod Test_896150_Liquidate {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -604,11 +604,6 @@ mod Test_896150_Liquidate {
                                             .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
-                                            .try_into()
-                                            .unwrap(),
-                                        fee: 0x20c49ba5e353f80000000000000000,
-                                        tick_spacing: 1000,
                                         extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IStarkgateERC20<TContractState> {
@@ -7,37 +7,23 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_896150_Liquidate {
-    use snforge_std::{
-        start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load, store, prank, CheatSpan
-    };
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address
-    };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait},
-        test::{
-            setup::{deploy_with_args, deploy_contract},
-            mock_oracle::{IMockPragmaOracleDispatcher, IMockPragmaOracleDispatcherTrait}
-        },
-        extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait}
-    };
+    use alexandria_math::i257::I257Trait;
+    use core::num::traits::Zero;
+    use ekubo::interfaces::core::ICoreDispatcher;
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use ekubo::types::keys::PoolKey;
+    use snforge_std::{CheatSpan, cheat_caller_address, load, store};
+    use starknet::{ContractAddress, get_contract_address};
+    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::mock_oracle::{IMockPragmaOracleDispatcher, IMockPragmaOracleDispatcherTrait};
+    use vesu::test::setup_v2::{deploy_contract, deploy_with_args};
+    use vesu::units::{SCALE, SCALE_128};
     use vesu_periphery::liquidate::{
-        ILiquidateDispatcher, ILiquidateDispatcherTrait, LiquidateParams, LiquidateResponse
+        ILiquidateDispatcher, ILiquidateDispatcherTrait, LiquidateParams, LiquidateResponse,
     };
-
-    use vesu_periphery::swap::{RouteNode, TokenAmount, Swap};
-
+    use vesu_periphery::swap::{RouteNode, Swap, TokenAmount};
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
     const MIN_SQRT_RATIO_LIMIT: u256 = 18446748437148339061;
@@ -45,7 +31,7 @@ mod Test_896150_Liquidate {
 
     struct TestConfig {
         ekubo: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         liquidate: ILiquidateDispatcher,
         pool_id: felt252,
         pool_key: PoolKey,
@@ -60,41 +46,41 @@ mod Test_896150_Liquidate {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: contract_address_const::<
-                0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
-            >()
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+                .try_into()
+                .unwrap(),
         };
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
         let liquidate = ILiquidateDispatcher {
             contract_address: deploy_with_args(
                 "Liquidate",
-                array![ekubo.contract_address.into(), singleton.contract_address.into()]
-            )
+                array![ekubo.contract_address.into(), singleton.contract_address.into()],
+            ),
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-            >()
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+                .try_into()
+                .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-            >()
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                .try_into()
+                .unwrap(),
         };
 
         let pool_id = 2198503327643286920898110335698706244522220458610657370981979460625005526824;
@@ -104,7 +90,7 @@ mod Test_896150_Liquidate {
             token1: usdc.contract_address,
             fee: 170141183460469235273462165868118016,
             tick_spacing: 1000,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_2 = PoolKey {
@@ -112,7 +98,7 @@ mod Test_896150_Liquidate {
             token1: usdt.contract_address,
             fee: 8507159232437450533281168781287096,
             tick_spacing: 25,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_3 = PoolKey {
@@ -120,7 +106,7 @@ mod Test_896150_Liquidate {
             token1: usdc.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_4 = PoolKey {
@@ -128,24 +114,22 @@ mod Test_896150_Liquidate {
             token1: eth.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let user = get_contract_address();
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdc.contract_address), minter);
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 100000_000_000);
-        stop_prank(CheatTarget::One(usdc.contract_address));
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdt.contract_address), minter);
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 100000_000_000);
-        stop_prank(CheatTarget::One(usdt.contract_address));
 
         let test_config = TestConfig {
             ekubo,
@@ -159,7 +143,7 @@ mod Test_896150_Liquidate {
             eth,
             usdc,
             usdt,
-            user
+            user,
         };
 
         test_config
@@ -179,31 +163,29 @@ mod Test_896150_Liquidate {
             collateral: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: 14000_000_000.into()
+                value: 14000_000_000.into(),
             },
             debt: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: (3 * SCALE).into()
+                value: (3 * SCALE).into(),
             },
-            data: ArrayTrait::new().span()
+            data: ArrayTrait::new().span(),
         };
 
-        start_prank(CheatTarget::One(usdc.contract_address), user);
-        usdc.approve(singleton.contract_address, params.collateral.value.abs);
-        stop_prank(CheatTarget::One(usdc.contract_address));
+        cheat_caller_address(usdc.contract_address, user, CheatSpan::TargetCalls(1));
+        usdc.approve(singleton.contract_address, params.collateral.value.abs());
 
-        start_prank(CheatTarget::One(singleton.contract_address), user);
+        cheat_caller_address(singleton.contract_address, user, CheatSpan::TargetCalls(1));
         singleton.modify_position(params);
-        stop_prank(CheatTarget::One(singleton.contract_address));
 
         let (_, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(collateral + 1 == params.collateral.value.abs);
-        assert!(debt - 1 == params.debt.value.abs);
+        assert!(collateral + 1 == params.collateral.value.abs());
+        assert!(debt - 1 == params.debt.value.abs());
 
         let mock_pragma_oracle = IMockPragmaOracleDispatcher {
-            contract_address: deploy_contract("MockPragmaOracle")
+            contract_address: deploy_contract("MockPragmaOracle"),
         };
         mock_pragma_oracle.set_num_sources_aggregated('USDC/USD', 10);
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
@@ -216,18 +198,18 @@ mod Test_896150_Liquidate {
         store(
             extension,
             selector!("oracle_address"),
-            array![mock_pragma_oracle.contract_address.into()].span()
+            array![mock_pragma_oracle.contract_address.into()].span(),
         );
 
         // reduce oracle price
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 / 2);
 
-        let liquidator = contract_address_const::<'liquidator'>();
+        let liquidator = 'liquidator'.try_into().unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        prank(CheatTarget::One(liquidate.contract_address), liquidator, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -245,27 +227,27 @@ mod Test_896150_Liquidate {
                                 RouteNode {
                                     pool_key: pool_key,
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
-                        }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
+                        },
                     ],
                     liquidate_swap_limit_amount: 8000_000_000,
                     liquidate_swap_weights: array![SCALE_128],
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
 
         assert!(response.liquidated_collateral == collateral);
         assert!(response.repaid_debt == debt);
         assert!(
             response.residual_collateral != 0
-                && response.residual_collateral == usdc.balanceOf(liquidator)
+                && response.residual_collateral == usdc.balanceOf(liquidator),
         );
         assert!(eth.balanceOf(liquidate.contract_address) == 0);
         assert!(usdc.balanceOf(liquidate.contract_address) == 0);
@@ -289,31 +271,29 @@ mod Test_896150_Liquidate {
             collateral: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: 14000_000_000.into()
+                value: 14000_000_000.into(),
             },
             debt: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: (3 * SCALE).into()
+                value: (3 * SCALE).into(),
             },
-            data: ArrayTrait::new().span()
+            data: ArrayTrait::new().span(),
         };
 
-        start_prank(CheatTarget::One(usdc.contract_address), user);
-        usdc.approve(singleton.contract_address, params.collateral.value.abs);
-        stop_prank(CheatTarget::One(usdc.contract_address));
+        cheat_caller_address(usdc.contract_address, user, CheatSpan::TargetCalls(1));
+        usdc.approve(singleton.contract_address, params.collateral.value.abs());
 
-        start_prank(CheatTarget::One(singleton.contract_address), user);
+        cheat_caller_address(singleton.contract_address, user, CheatSpan::TargetCalls(1));
         singleton.modify_position(params);
-        stop_prank(CheatTarget::One(singleton.contract_address));
 
         let (_, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(collateral + 1 == params.collateral.value.abs);
-        assert!(debt - 1 == params.debt.value.abs);
+        assert!(collateral + 1 == params.collateral.value.abs());
+        assert!(debt - 1 == params.debt.value.abs());
 
         let mock_pragma_oracle = IMockPragmaOracleDispatcher {
-            contract_address: deploy_contract("MockPragmaOracle")
+            contract_address: deploy_contract("MockPragmaOracle"),
         };
         mock_pragma_oracle.set_num_sources_aggregated('USDC/USD', 10);
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
@@ -326,18 +306,18 @@ mod Test_896150_Liquidate {
         store(
             extension,
             selector!("oracle_address"),
-            array![mock_pragma_oracle.contract_address.into()].span()
+            array![mock_pragma_oracle.contract_address.into()].span(),
         );
 
         // reduce oracle price
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = contract_address_const::<'liquidator'>();
+        let liquidator = 'liquidator'.try_into().unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        prank(CheatTarget::One(liquidate.contract_address), liquidator, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
         let response: LiquidateResponse = liquidate
             .liquidate(
                 LiquidateParams {
@@ -354,27 +334,27 @@ mod Test_896150_Liquidate {
                                 RouteNode {
                                     pool_key: pool_key,
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
-                        }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
+                        },
                     ],
                     liquidate_swap_limit_amount: 14000_000_000,
                     liquidate_swap_weights: array![SCALE_128],
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
 
         assert!(response.liquidated_collateral < collateral);
         assert!(response.repaid_debt == debt);
         assert!(
             response.residual_collateral != 0
-                && response.residual_collateral == usdc.balanceOf(liquidator)
+                && response.residual_collateral == usdc.balanceOf(liquidator),
         );
         assert!(eth.balanceOf(liquidate.contract_address) == 0);
         assert!(usdc.balanceOf(liquidate.contract_address) == 0);
@@ -398,31 +378,29 @@ mod Test_896150_Liquidate {
             collateral: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: 14000_000_000.into()
+                value: 14000_000_000.into(),
             },
             debt: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: (3 * SCALE).into()
+                value: (3 * SCALE).into(),
             },
-            data: ArrayTrait::new().span()
+            data: ArrayTrait::new().span(),
         };
 
-        start_prank(CheatTarget::One(usdc.contract_address), user);
-        usdc.approve(singleton.contract_address, params.collateral.value.abs);
-        stop_prank(CheatTarget::One(usdc.contract_address));
+        cheat_caller_address(usdc.contract_address, user, CheatSpan::TargetCalls(1));
+        usdc.approve(singleton.contract_address, params.collateral.value.abs());
 
-        start_prank(CheatTarget::One(singleton.contract_address), user);
+        cheat_caller_address(singleton.contract_address, user, CheatSpan::TargetCalls(1));
         singleton.modify_position(params);
-        stop_prank(CheatTarget::One(singleton.contract_address));
 
         let (_, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(collateral + 1 == params.collateral.value.abs);
-        assert!(debt - 1 == params.debt.value.abs);
+        assert!(collateral + 1 == params.collateral.value.abs());
+        assert!(debt - 1 == params.debt.value.abs());
 
         let mock_pragma_oracle = IMockPragmaOracleDispatcher {
-            contract_address: deploy_contract("MockPragmaOracle")
+            contract_address: deploy_contract("MockPragmaOracle"),
         };
         mock_pragma_oracle.set_num_sources_aggregated('USDC/USD', 10);
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
@@ -435,18 +413,18 @@ mod Test_896150_Liquidate {
         store(
             extension,
             selector!("oracle_address"),
-            array![mock_pragma_oracle.contract_address.into()].span()
+            array![mock_pragma_oracle.contract_address.into()].span(),
         );
 
         // reduce oracle price
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = contract_address_const::<'liquidator'>();
+        let liquidator = 'liquidator'.try_into().unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        prank(CheatTarget::One(liquidate.contract_address), liquidator, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -464,27 +442,27 @@ mod Test_896150_Liquidate {
                                 RouteNode {
                                     pool_key: pool_key,
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
-                        }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
+                        },
                     ],
                     liquidate_swap_weights: array![SCALE_128],
                     liquidate_swap_limit_amount: 12000_000_000,
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
 
         assert!(response.liquidated_collateral < collateral);
         assert!(response.repaid_debt == debt / 2);
         assert!(
             response.residual_collateral != 0
-                && response.residual_collateral == usdc.balanceOf(liquidator)
+                && response.residual_collateral == usdc.balanceOf(liquidator),
         );
         assert!(eth.balanceOf(liquidate.contract_address) == 0);
         assert!(usdc.balanceOf(liquidate.contract_address) == 0);
@@ -511,27 +489,27 @@ mod Test_896150_Liquidate {
                                 RouteNode {
                                     pool_key: pool_key,
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
-                        }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
+                        },
                     ],
                     liquidate_swap_limit_amount: 12000_000_000,
                     liquidate_swap_weights: array![SCALE_128],
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
 
         assert!(response.liquidated_collateral < collateral);
         assert!(response.repaid_debt == debt_);
         assert!(
             response.residual_collateral != 0
-                && response.residual_collateral < usdc.balanceOf(liquidator)
+                && response.residual_collateral < usdc.balanceOf(liquidator),
         );
         assert!(eth.balanceOf(liquidate.contract_address) == 0);
         assert!(usdc.balanceOf(liquidate.contract_address) == 0);
@@ -555,31 +533,29 @@ mod Test_896150_Liquidate {
             collateral: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: 14000_000_000.into()
+                value: 14000_000_000.into(),
             },
             debt: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: (3 * SCALE).into()
+                value: (3 * SCALE).into(),
             },
-            data: ArrayTrait::new().span()
+            data: ArrayTrait::new().span(),
         };
 
-        start_prank(CheatTarget::One(usdc.contract_address), user);
-        usdc.approve(singleton.contract_address, params.collateral.value.abs);
-        stop_prank(CheatTarget::One(usdc.contract_address));
+        cheat_caller_address(usdc.contract_address, user, CheatSpan::TargetCalls(1));
+        usdc.approve(singleton.contract_address, params.collateral.value.abs());
 
-        start_prank(CheatTarget::One(singleton.contract_address), user);
+        cheat_caller_address(singleton.contract_address, user, CheatSpan::TargetCalls(1));
         singleton.modify_position(params);
-        stop_prank(CheatTarget::One(singleton.contract_address));
 
         let (_, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(collateral + 1 == params.collateral.value.abs);
-        assert!(debt - 1 == params.debt.value.abs);
+        assert!(collateral + 1 == params.collateral.value.abs());
+        assert!(debt - 1 == params.debt.value.abs());
 
         let mock_pragma_oracle = IMockPragmaOracleDispatcher {
-            contract_address: deploy_contract("MockPragmaOracle")
+            contract_address: deploy_contract("MockPragmaOracle"),
         };
         mock_pragma_oracle.set_num_sources_aggregated('USDC/USD', 10);
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
@@ -592,18 +568,18 @@ mod Test_896150_Liquidate {
         store(
             extension,
             selector!("oracle_address"),
-            array![mock_pragma_oracle.contract_address.into()].span()
+            array![mock_pragma_oracle.contract_address.into()].span(),
         );
 
         // reduce oracle price
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = contract_address_const::<'liquidator'>();
+        let liquidator = 'liquidator'.try_into().unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        prank(CheatTarget::One(liquidate.contract_address), liquidator, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -620,136 +596,141 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
+                                        fee: 0x20c49ba5e353f80000000000000000,
+                                        tick_spacing: 1000,
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
                                         tick_spacing: 200,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
+                                    skip_ahead: 0,
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
                                         tick_spacing: 200,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
+                                    skip_ahead: 0,
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-                                        >(),
+                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x14f8b588e368f1000000000000000,
                                         tick_spacing: 20,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                     ],
                     liquidate_swap_limit_amount: 12000_000_000,
                     liquidate_swap_weights: array![
-                        SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4
+                        SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4,
                     ],
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
 
         assert!(response.liquidated_collateral < collateral);
         assert!(response.repaid_debt == debt);
         assert!(
             response.residual_collateral != 0
-                && response.residual_collateral == usdc.balanceOf(liquidator)
+                && response.residual_collateral == usdc.balanceOf(liquidator),
         );
         assert!(eth.balanceOf(liquidate.contract_address) == 0);
         assert!(usdc.balanceOf(liquidate.contract_address) == 0);
@@ -774,31 +755,29 @@ mod Test_896150_Liquidate {
             collateral: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: 14000_000_000.into()
+                value: 14000_000_000.into(),
             },
             debt: Amount {
                 amount_type: AmountType::Delta,
                 denomination: AmountDenomination::Assets,
-                value: (3 * SCALE).into()
+                value: (3 * SCALE).into(),
             },
-            data: ArrayTrait::new().span()
+            data: ArrayTrait::new().span(),
         };
 
-        start_prank(CheatTarget::One(usdc.contract_address), user);
-        usdc.approve(singleton.contract_address, params.collateral.value.abs);
-        stop_prank(CheatTarget::One(usdc.contract_address));
+        cheat_caller_address(usdc.contract_address, user, CheatSpan::TargetCalls(1));
+        usdc.approve(singleton.contract_address, params.collateral.value.abs());
 
-        start_prank(CheatTarget::One(singleton.contract_address), user);
+        cheat_caller_address(singleton.contract_address, user, CheatSpan::TargetCalls(1));
         singleton.modify_position(params);
-        stop_prank(CheatTarget::One(singleton.contract_address));
 
         let (_, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(collateral + 1 == params.collateral.value.abs);
-        assert!(debt - 1 == params.debt.value.abs);
+        assert!(collateral + 1 == params.collateral.value.abs());
+        assert!(debt - 1 == params.debt.value.abs());
 
         let mock_pragma_oracle = IMockPragmaOracleDispatcher {
-            contract_address: deploy_contract("MockPragmaOracle")
+            contract_address: deploy_contract("MockPragmaOracle"),
         };
         mock_pragma_oracle.set_num_sources_aggregated('USDC/USD', 10);
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
@@ -811,18 +790,20 @@ mod Test_896150_Liquidate {
         store(
             extension,
             selector!("oracle_address"),
-            array![mock_pragma_oracle.contract_address.into()].span()
+            array![mock_pragma_oracle.contract_address.into()].span(),
         );
 
         // reduce oracle price
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = contract_address_const::<'liquidator'>();
+        let liquidator = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+            .try_into()
+            .unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        prank(CheatTarget::One(liquidate.contract_address), liquidator, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
 
         liquidate
             .liquidate(
@@ -839,129 +820,129 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
                                         tick_spacing: 200,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
+                                    skip_ahead: 0,
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
                                         tick_spacing: 200,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                         Swap {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-                                        >(),
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
                                         tick_spacing: 1000,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
+                                    skip_ahead: 0,
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: contract_address_const::<
-                                            0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                        >(),
-                                        token1: contract_address_const::<
-                                            0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-                                        >(),
+                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                            .try_into()
+                                            .unwrap(),
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                            .try_into()
+                                            .unwrap(),
                                         fee: 0x14f8b588e368f1000000000000000,
                                         tick_spacing: 20,
-                                        extension: contract_address_const::<0x0>()
+                                        extension: 0x0.try_into().unwrap(),
                                     },
                                     sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                                    skip_ahead: 0
-                                }
+                                    skip_ahead: 0,
+                                },
                             ],
                             token_amount: TokenAmount {
-                                token: eth.contract_address, amount: Zero::zero()
-                            }
+                                token: eth.contract_address, amount: Zero::zero(),
+                            },
                         },
                     ],
                     liquidate_swap_limit_amount: 12000_000_000,
                     liquidate_swap_weights: array![
-                        SCALE_128 / 2, SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4
+                        SCALE_128 / 2, SCALE_128 / 4, SCALE_128 / 4, SCALE_128 / 4,
                     ],
                     withdraw_swap: array![],
                     withdraw_swap_limit_amount: 0,
-                    withdraw_swap_weights: array![]
-                }
+                    withdraw_swap_weights: array![],
+                },
             );
     }
 }

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -51,7 +51,7 @@ mod Test_896150_Liquidate {
                 .unwrap(),
         };
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };
@@ -68,17 +68,17 @@ mod Test_896150_Liquidate {
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                 .try_into()
                 .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                 .try_into()
                 .unwrap(),
         };
@@ -618,10 +618,10 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
@@ -633,10 +633,10 @@ mod Test_896150_Liquidate {
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
@@ -655,10 +655,10 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
@@ -677,7 +677,7 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
                                         token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
@@ -692,7 +692,7 @@ mod Test_896150_Liquidate {
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
@@ -792,7 +792,7 @@ mod Test_896150_Liquidate {
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+        let liquidator = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
             .try_into()
             .unwrap();
 
@@ -837,10 +837,10 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
@@ -852,10 +852,10 @@ mod Test_896150_Liquidate {
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                        token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
@@ -874,10 +874,10 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x68db8bac710cb4000000000000000,
@@ -896,7 +896,7 @@ mod Test_896150_Liquidate {
                             route: array![
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                        token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
                                         token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
@@ -911,7 +911,7 @@ mod Test_896150_Liquidate {
                                 },
                                 RouteNode {
                                     pool_key: PoolKey {
-                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                        token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
                                         token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -127,7 +127,7 @@ mod Test_896150_Liquidate {
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
+        cheat_caller_address(usdt.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 100000_000_000);
 
@@ -209,7 +209,7 @@ mod Test_896150_Liquidate {
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidate.contract_address, liquidator, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -317,7 +317,7 @@ mod Test_896150_Liquidate {
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidate.contract_address, liquidator, CheatSpan::TargetCalls(1));
         let response: LiquidateResponse = liquidate
             .liquidate(
                 LiquidateParams {
@@ -424,7 +424,7 @@ mod Test_896150_Liquidate {
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidate.contract_address, liquidator, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -579,7 +579,7 @@ mod Test_896150_Liquidate {
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidate.contract_address, liquidator, CheatSpan::TargetCalls(1));
 
         let response: LiquidateResponse = liquidate
             .liquidate(
@@ -680,7 +680,7 @@ mod Test_896150_Liquidate {
                                         token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
@@ -695,7 +695,7 @@ mod Test_896150_Liquidate {
                                         token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x14f8b588e368f1000000000000000,
@@ -792,13 +792,11 @@ mod Test_896150_Liquidate {
 
         mock_pragma_oracle.set_price('USDC/USD', SCALE_128 * 8 / 10);
 
-        let liquidator = 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            .try_into()
-            .unwrap();
+        let liquidator = 'liquidator'.try_into().unwrap();
 
         assert!(usdc.balanceOf(liquidator) == 0);
 
-        cheat_caller_address(liquidator, liquidate.contract_address, CheatSpan::TargetCalls(1));
+        cheat_caller_address(liquidate.contract_address, liquidator, CheatSpan::TargetCalls(1));
 
         liquidate
             .liquidate(
@@ -899,7 +897,7 @@ mod Test_896150_Liquidate {
                                         token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x20c49ba5e353f80000000000000000,
@@ -914,7 +912,7 @@ mod Test_896150_Liquidate {
                                         token0: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                             .try_into()
                                             .unwrap(),
-                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb
+                                        token1: 0x68f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                                             .try_into()
                                             .unwrap(),
                                         fee: 0x14f8b588e368f1000000000000000,

--- a/tests/test_liquidate.cairo
+++ b/tests/test_liquidate.cairo
@@ -63,7 +63,7 @@ mod Test_896150_Liquidate {
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -45,7 +45,7 @@ mod Test_896150_ManagedVault {
                 .unwrap(),
         };
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };
@@ -57,17 +57,17 @@ mod Test_896150_ManagedVault {
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IStarkgateERC20<TContractState> {
@@ -7,35 +7,19 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_896150_ManagedVault {
-    use snforge_std::{start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load};
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address
-    };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait}, test::setup::deploy_with_args,
-        common::{i257, i257_new},
-        extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait}
-    };
-    use vesu_periphery::{
-        multiply::{
-            IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverParams, IncreaseLeverParams,
-            DecreaseLeverParams, ModifyLeverAction
-        },
-        swap::{RouteNode, TokenAmount, Swap},
-        managed_vault::{IManagedVaultDispatcher, IManagedVaultDispatcherTrait}
-    };
-
+    use alexandria_math::i257::I257Trait;
+    use ekubo::interfaces::core::ICoreDispatcher;
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use ekubo::types::keys::PoolKey;
+    use snforge_std::{CheatSpan, cheat_caller_address, load};
+    use starknet::{ContractAddress, get_contract_address};
+    use vesu::data_model::{Amount, AmountDenomination, AmountType};
+    use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::setup_v2::deploy_with_args;
+    use vesu::units::SCALE;
+    use vesu_periphery::managed_vault::{IManagedVaultDispatcher, IManagedVaultDispatcherTrait};
+    use vesu_periphery::multiply::IMultiplyDispatcher;
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
     const MIN_SQRT_RATIO_LIMIT: u256 = 18446748437148339061;
@@ -43,7 +27,7 @@ mod Test_896150_ManagedVault {
 
     struct TestConfig {
         ekubo: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         multiply: IMultiplyDispatcher,
         managed_vault: IManagedVaultDispatcher,
         pool_id: felt252,
@@ -56,35 +40,36 @@ mod Test_896150_ManagedVault {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: contract_address_const::<
-                0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
-            >()
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+                .try_into()
+                .unwrap(),
         };
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
         let multiply = IMultiplyDispatcher {
             contract_address: deploy_with_args(
-                "Multiply", array![ekubo.contract_address.into(), singleton.contract_address.into()]
-            )
+                "Multiply",
+                array![ekubo.contract_address.into(), singleton.contract_address.into()],
+            ),
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-            >()
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+                .try_into()
+                .unwrap(),
         };
         // let strk = IERC20Dispatcher {
         //     contract_address: contract_address_const::<
@@ -99,7 +84,7 @@ mod Test_896150_ManagedVault {
             token1: usdc.contract_address,
             fee: 170141183460469235273462165868118016,
             tick_spacing: 1000,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let calldata: Array<felt252> = array![
@@ -109,14 +94,15 @@ mod Test_896150_ManagedVault {
             usdc.contract_address.into(),
             false.into(),
             get_contract_address().into(),
+            get_contract_address().into(),
             singleton.contract_address.into(),
             ekubo.contract_address.into(),
             multiply.contract_address.into(),
-            0
+            0,
         ];
 
         let managed_vault = IManagedVaultDispatcher {
-            contract_address: deploy_with_args("ManagedVault", calldata)
+            contract_address: deploy_with_args("ManagedVault", calldata),
         };
         managed_vault.set_price_source(singleton.extension(pool_id), pool_id);
 
@@ -124,20 +110,18 @@ mod Test_896150_ManagedVault {
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdc.contract_address), minter);
+        cheat_caller_address((usdc.contract_address), minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 10000_000_000);
-        stop_prank(CheatTarget::One(usdc.contract_address));
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdt.contract_address), minter);
+        cheat_caller_address((usdt.contract_address), minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10010_000_000);
-        stop_prank(CheatTarget::One(usdt.contract_address));
 
         let test_config = TestConfig {
-            ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user
+            ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,
         };
 
         test_config
@@ -147,16 +131,9 @@ mod Test_896150_ManagedVault {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_managed_vault_deposit() {
-        let TestConfig { singleton,
-        multiply,
-        managed_vault,
-        pool_id,
-        pool_key,
-        eth,
-        usdc,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, user, ..,
+        } = setup();
 
         let usdc_balance_before = usdc.balanceOf(user);
 
@@ -167,7 +144,7 @@ mod Test_896150_ManagedVault {
         assert!(
             IERC20Dispatcher { contract_address: managed_vault.contract_address }
                 .balanceOf(user) == 10000
-                * SCALE
+                * SCALE,
         );
 
         let (extension, pool_id) = managed_vault.price_source();
@@ -184,13 +161,13 @@ mod Test_896150_ManagedVault {
                 collateral: Amount {
                     amount_type: AmountType::Delta,
                     denomination: AmountDenomination::Assets,
-                    value: i257_new(10000_000_000, false)
+                    value: I257Trait::new(10000_000_000, false),
                 },
                 debt: Amount {
                     amount_type: AmountType::Delta,
                     denomination: AmountDenomination::Assets,
-                    value: i257_new(0, false)
-                }
+                    value: I257Trait::new(0, false),
+                },
             );
 
         assert!(managed_vault.nav() >= 10000 * price.value - 10000000000000);
@@ -203,13 +180,13 @@ mod Test_896150_ManagedVault {
                 collateral: Amount {
                     amount_type: AmountType::Target,
                     denomination: AmountDenomination::Assets,
-                    value: i257_new(0, false)
+                    value: I257Trait::new(0, false),
                 },
                 debt: Amount {
                     amount_type: AmountType::Delta,
                     denomination: AmountDenomination::Assets,
-                    value: i257_new(0, false)
-                }
+                    value: I257Trait::new(0, false),
+                },
             );
 
         assert!(managed_vault.nav() >= 10000 * price.value - 10000000000000);
@@ -217,15 +194,15 @@ mod Test_896150_ManagedVault {
         managed_vault
             .request_redeem(
                 IERC20Dispatcher { contract_address: managed_vault.contract_address }
-                    .balanceOf(user)
+                    .balanceOf(user),
             );
 
         managed_vault.redeem(user, user);
-    // assert!(managed_vault.nav() == 0.into());
+        // assert!(managed_vault.nav() == 0.into());
 
-    // singleton.modify_delegation(pool_id, multiply.contract_address, true);
+        // singleton.modify_delegation(pool_id, multiply.contract_address, true);
 
-    // let increase_lever_params = IncreaseLeverParams {
+        // let increase_lever_params = IncreaseLeverParams {
     //     pool_id,
     //     collateral_asset: usdc.contract_address,
     //     debt_asset: eth.contract_address,
@@ -249,20 +226,20 @@ mod Test_896150_ManagedVault {
     //     lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
     // };
 
-    // let modify_lever_params = ModifyLeverParams {
+        // let modify_lever_params = ModifyLeverParams {
     //     action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
     // };
 
-    // multiply.modify_lever(modify_lever_params);
+        // multiply.modify_lever(modify_lever_params);
 
-    // let (_, collateral, _) = singleton
+        // let (_, collateral, _) = singleton
     //     .position(pool_id, usdc.contract_address, eth.contract_address, user);
 
-    // let y: @Swap = (increase_lever_params.lever_swap[0]);
+        // let y: @Swap = (increase_lever_params.lever_swap[0]);
     // let x: u256 = (*y.token_amount.amount.mag).into();
     // assert!(collateral + 1 == increase_lever_params.add_margin.into() + x);
 
-    // assert!(
+        // assert!(
     //     usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
     // );
     }

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -110,13 +110,13 @@ mod Test_896150_ManagedVault {
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        cheat_caller_address((usdc.contract_address), minter, CheatSpan::TargetCalls(1));
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 10000_000_000);
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        cheat_caller_address((usdt.contract_address), minter, CheatSpan::TargetCalls(1));
+        cheat_caller_address(usdt.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10010_000_000);
 

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -40,7 +40,7 @@ mod Test_896150_ManagedVault {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -1347,7 +1347,7 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
+                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793ee
                                     .try_into()
                                     .unwrap(),
                                 token1: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
@@ -1355,7 +1355,7 @@ mod Test_896150_Multiply {
                                     .unwrap(),
                                 fee: 0xc49ba5e353f7d00000000000000000,
                                 tick_spacing: 354892,
-                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fd
+                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fdc
                                     .try_into()
                                     .unwrap(),
                             },
@@ -1364,7 +1364,7 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
+                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793ee
                                     .try_into()
                                     .unwrap(),
                                 token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IStarkgateERC20<TContractState> {
@@ -7,31 +7,24 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_896150_Multiply {
-    use snforge_std::{start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load};
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address
-    };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait}, test::setup::deploy_with_args,
-        common::{i257, i257_new}
-    };
+    use alexandria_math::i257::{I257Trait, i257};
+    use core::num::traits::Zero;
+    use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use ekubo::types::i129::i129Trait;
+    use ekubo::types::keys::PoolKey;
+    use snforge_std::{CheatSpan, cheat_caller_address, load};
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
+    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::setup_v2::deploy_with_args;
+    use vesu::units::{SCALE, SCALE_128};
+    use vesu_periphery::i129_new;
     use vesu_periphery::multiply::{
-        IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverParams, IncreaseLeverParams,
-        DecreaseLeverParams, ModifyLeverAction
+        DecreaseLeverParams, IMultiplyDispatcher, IMultiplyDispatcherTrait, IncreaseLeverParams,
+        ModifyLeverAction, ModifyLeverParams,
     };
-    use vesu_periphery::swap::{RouteNode, TokenAmount, Swap};
-
+    use vesu_periphery::swap::{RouteNode, Swap, TokenAmount};
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
     const MIN_SQRT_RATIO_LIMIT: u256 = 18446748437148339061;
@@ -39,7 +32,7 @@ mod Test_896150_Multiply {
 
     struct TestConfig {
         ekubo: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         multiply: IMultiplyDispatcher,
         pool_id: felt252,
         pool_key: PoolKey,
@@ -54,40 +47,41 @@ mod Test_896150_Multiply {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: contract_address_const::<
-                0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
-            >()
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+                .try_into()
+                .unwrap(),
         };
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
         let multiply = IMultiplyDispatcher {
             contract_address: deploy_with_args(
-                "Multiply", array![ekubo.contract_address.into(), singleton.contract_address.into()]
-            )
+                "Multiply",
+                array![ekubo.contract_address.into(), singleton.contract_address.into()],
+            ),
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-            >()
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+                .try_into()
+                .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-            >()
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                .try_into()
+                .unwrap(),
         };
 
         let pool_id = 2198503327643286920898110335698706244522220458610657370981979460625005526824;
@@ -97,7 +91,7 @@ mod Test_896150_Multiply {
             token1: usdc.contract_address,
             fee: 170141183460469235273462165868118016,
             tick_spacing: 1000,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_2 = PoolKey {
@@ -105,7 +99,7 @@ mod Test_896150_Multiply {
             token1: usdt.contract_address,
             fee: 8507159232437450533281168781287096,
             tick_spacing: 25,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_3 = PoolKey {
@@ -113,7 +107,7 @@ mod Test_896150_Multiply {
             token1: usdc.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_4 = PoolKey {
@@ -121,24 +115,22 @@ mod Test_896150_Multiply {
             token1: eth.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let user = get_contract_address();
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdc.contract_address), minter);
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 10000_000_000);
-        stop_prank(CheatTarget::One(usdc.contract_address));
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdt.contract_address), minter);
+        cheat_caller_address(usdt.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10010_000_000);
-        stop_prank(CheatTarget::One(usdt.contract_address));
 
         let test_config = TestConfig {
             ekubo,
@@ -152,7 +144,7 @@ mod Test_896150_Multiply {
             eth,
             usdc,
             usdt,
-            user
+            user,
         };
 
         test_config
@@ -182,7 +174,7 @@ mod Test_896150_Multiply {
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -192,7 +184,7 @@ mod Test_896150_Multiply {
 
         assert!(collateral + 1 == increase_lever_params.add_margin.into());
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -219,20 +211,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
-                    }
-                }
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
+                    },
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -245,7 +237,7 @@ mod Test_896150_Multiply {
         assert!(collateral + 1 == increase_lever_params.add_margin.into() + x);
 
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -272,20 +264,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: eth.contract_address,
                         amount: i129_new((44000000000000000).try_into().unwrap(), false),
-                    }
-                }
+                    },
+                },
             ],
             lever_swap_limit_amount: 0,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -298,7 +290,7 @@ mod Test_896150_Multiply {
         assert!(debt - 1 == x);
 
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -306,17 +298,9 @@ mod Test_896150_Multiply {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_modify_lever_margin_asset_swap_exact_out() {
-        let TestConfig { singleton,
-        multiply,
-        pool_id,
-        pool_key,
-        pool_key_2,
-        eth,
-        usdc,
-        usdt,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, pool_id, pool_key, pool_key_2, eth, usdc, usdt, user, ..,
+        } = setup();
 
         let usdt_balance_before = usdt.balanceOf(user);
 
@@ -335,34 +319,34 @@ mod Test_896150_Multiply {
                         RouteNode {
                             pool_key: pool_key_2,
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((10000_000_000).try_into().unwrap(), true)
+                        amount: i129_new((10000_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
             margin_swap_limit_amount: (10010_000_000).try_into().unwrap(),
             lever_swap: array![
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -384,17 +368,9 @@ mod Test_896150_Multiply {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_modify_lever_margin_asset_swap_exact_in() {
-        let TestConfig { singleton,
-        multiply,
-        pool_id,
-        pool_key,
-        pool_key_2,
-        eth,
-        usdc,
-        usdt,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, pool_id, pool_key, pool_key_2, eth, usdc, usdt, user, ..,
+        } = setup();
 
         let usdt_balance_before = usdt.balanceOf(user);
 
@@ -413,34 +389,34 @@ mod Test_896150_Multiply {
                         RouteNode {
                             pool_key: pool_key_2,
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdt.contract_address,
-                        amount: i129_new((10010_000_000).try_into().unwrap(), false)
+                        amount: i129_new((10010_000_000).try_into().unwrap(), false),
                     },
-                }
+                },
             ],
             margin_swap_limit_amount: Zero::zero(),
             lever_swap: array![
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -482,20 +458,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((300_000_000).try_into().unwrap(), true)
-                    }
-                }
+                        amount: i129_new((300_000_000).try_into().unwrap(), true),
+                    },
+                },
             ],
-            lever_swap_limit_amount: 120000000000000000, // 0.12 ETH
+            lever_swap_limit_amount: 120000000000000000 // 0.12 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -516,25 +492,25 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((collateral_amount / 200).try_into().unwrap(), false)
+                        amount: i129_new((collateral_amount / 200).try_into().unwrap(), false),
                     },
-                }
+                },
             ],
             lever_swap_limit_amount: 0,
             lever_swap_weights: array![],
             withdraw_swap: array![],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![],
-            close_position: false
+            close_position: false,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -570,20 +546,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((300_000_000).try_into().unwrap(), true)
+                        amount: i129_new((300_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 120000000000000000, // 0.12 ETH
+            lever_swap_limit_amount: 120000000000000000 // 0.12 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -606,11 +582,11 @@ mod Test_896150_Multiply {
             withdraw_swap: array![],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![],
-            close_position: false
+            close_position: false,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -643,20 +619,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
-                    }
-                }
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
+                    },
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -677,14 +653,14 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: eth.contract_address,
-                        amount: i129_new(debt_amount.try_into().unwrap(), true)
-                    }
-                }
+                        amount: i129_new(debt_amount.try_into().unwrap(), true),
+                    },
+                },
             ],
             lever_swap_limit_amount: 121_000_000_u128,
             lever_swap_weights: array![],
@@ -695,7 +671,7 @@ mod Test_896150_Multiply {
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -708,7 +684,7 @@ mod Test_896150_Multiply {
         assert!(debt == debt_amount - lever_swap_amount);
 
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before + decrease_lever_params.sub_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before + decrease_lever_params.sub_margin.into(),
         );
     }
 
@@ -716,17 +692,9 @@ mod Test_896150_Multiply {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_modify_lever_withdraw_swap_exact_in() {
-        let TestConfig { singleton,
-        multiply,
-        pool_id,
-        pool_key,
-        pool_key_2,
-        eth,
-        usdc,
-        usdt,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, pool_id, pool_key, pool_key_2, eth, usdc, usdt, user, ..,
+        } = setup();
 
         usdc.approve(multiply.contract_address, 10000_000_000.into());
         singleton.modify_delegation(pool_id, multiply.contract_address, true);
@@ -743,20 +711,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((300_000_000).try_into().unwrap(), true)
+                        amount: i129_new((300_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 120000000000000000, // 0.12 ETH
+            lever_swap_limit_amount: 120000000000000000 // 0.12 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -778,14 +746,14 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((collateral_amount / 200).try_into().unwrap(), false)
+                        amount: i129_new((collateral_amount / 200).try_into().unwrap(), false),
                     },
-                }
+                },
             ],
             lever_swap_limit_amount: 0,
             lever_swap_weights: array![],
@@ -795,13 +763,13 @@ mod Test_896150_Multiply {
                         RouteNode {
                             pool_key: pool_key_2,
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address, amount: Zero::zero(),
                     },
-                }
+                },
             ],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![SCALE_128],
@@ -809,7 +777,7 @@ mod Test_896150_Multiply {
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -824,7 +792,7 @@ mod Test_896150_Multiply {
         assert!(usdc.balanceOf(user) == usdc_balance_before);
         assert!(usdt.balanceOf(user) >= usdt_balance_before);
         assert!(
-            usdt.balanceOf(user) <= usdt_balance_before + decrease_lever_params.sub_margin.into()
+            usdt.balanceOf(user) <= usdt_balance_before + decrease_lever_params.sub_margin.into(),
         );
     }
 
@@ -850,20 +818,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -879,24 +847,22 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
-                    token_amount: TokenAmount {
-                        token: eth.contract_address, amount: Zero::zero(),
-                    },
-                }
+                    token_amount: TokenAmount { token: eth.contract_address, amount: Zero::zero() },
+                },
             ],
             lever_swap_limit_amount: 121_000_000_u128,
             lever_swap_weights: array![SCALE_128 * 2],
             withdraw_swap: array![],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![],
-            close_position: true
+            close_position: true,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -923,20 +889,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -954,24 +920,22 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
-                    token_amount: TokenAmount {
-                        token: eth.contract_address, amount: Zero::zero(),
-                    },
-                }
+                    token_amount: TokenAmount { token: eth.contract_address, amount: Zero::zero() },
+                },
             ],
             lever_swap_limit_amount: 121_000_000_u128,
             lever_swap_weights: array![SCALE_128],
             withdraw_swap: array![],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![],
-            close_position: true
+            close_position: true,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         let (_, collateral, debt) = singleton
@@ -979,9 +943,9 @@ mod Test_896150_Multiply {
 
         let modify_lever_response = multiply.modify_lever(modify_lever_params);
 
-        assert!(modify_lever_response.collateral_delta == i257_new(collateral, true));
-        assert!(modify_lever_response.debt_delta == i257_new(debt, true));
-        assert!(modify_lever_response.margin_delta <= i257_new(9999_000_000, true));
+        assert!(modify_lever_response.collateral_delta == I257Trait::new(collateral, true));
+        assert!(modify_lever_response.debt_delta == I257Trait::new(debt, true));
+        assert!(modify_lever_response.margin_delta <= I257Trait::new(9999_000_000, true));
 
         let (position, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
@@ -991,7 +955,7 @@ mod Test_896150_Multiply {
         assert!(debt == 0);
 
         assert!(
-            usdc.balanceOf(user) >= user_balance_before + decrease_lever_params.sub_margin.into()
+            usdc.balanceOf(user) >= user_balance_before + decrease_lever_params.sub_margin.into(),
         );
     }
 
@@ -999,16 +963,9 @@ mod Test_896150_Multiply {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_modify_lever_multi_swap() {
-        let TestConfig { singleton,
-        multiply,
-        pool_id,
-        pool_key_3,
-        pool_key_4,
-        eth,
-        usdc,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, pool_id, pool_key_3, pool_key_4, eth, usdc, user, ..,
+        } = setup();
 
         let usdc_balance_before = usdc.balanceOf(user);
 
@@ -1029,31 +986,31 @@ mod Test_896150_Multiply {
                         RouteNode {
                             pool_key: pool_key_3,
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: pool_key_4,
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         let modify_lever_response = multiply.modify_lever(modify_lever_params);
-        assert!(modify_lever_response.collateral_delta == i257_new(10110_000_000, false));
-        assert!(modify_lever_response.debt_delta > i257_new(0, false));
-        assert!(modify_lever_response.margin_delta == i257_new(10000_000_000, false));
+        assert!(modify_lever_response.collateral_delta == I257Trait::new(10110_000_000, false));
+        assert!(modify_lever_response.debt_delta > I257Trait::new(0, false));
+        assert!(modify_lever_response.margin_delta == I257Trait::new(10000_000_000, false));
 
         let (_, collateral, _) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
@@ -1063,7 +1020,7 @@ mod Test_896150_Multiply {
         assert!(collateral + 1 == increase_lever_params.add_margin.into() + lever_swap_amount);
 
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -1095,133 +1052,133 @@ mod Test_896150_Multiply {
                                 token1: usdc.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 2
-                        }
+                            skip_ahead: 2,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((55_000_000).try_into().unwrap(), true)
+                        amount: i129_new((55_000_000).try_into().unwrap(), true),
                     },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: usdc.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: eth.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((27_500_000).try_into().unwrap(), true)
+                        amount: i129_new((27_500_000).try_into().unwrap(), true),
                     },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: usdc.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: eth.contract_address,
                                 fee: 0x28f5c28f5c28f5c28f5c28f5c28f5c2,
                                 tick_spacing: 354892,
-                                extension: contract_address_const::<
-                                    0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fdc
-                                >()
+                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fd
+                                    .try_into()
+                                    .unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((13_750_000).try_into().unwrap(), true)
+                        amount: i129_new((13_750_000).try_into().unwrap(), true),
                     },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: usdc.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 token1: eth.contract_address,
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((13_750_000).try_into().unwrap(), true)
+                        amount: i129_new((13_750_000).try_into().unwrap(), true),
                     },
                 },
             ],
-            lever_swap_limit_amount: 44000000000000000, // 0.044 ETH
+            lever_swap_limit_amount: 44000000000000000 // 0.044 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         let modify_lever_response = multiply.modify_lever(modify_lever_params);
-        assert!(modify_lever_response.collateral_delta == i257_new(10110_000_000, false));
-        assert!(modify_lever_response.debt_delta > i257_new(0, false));
-        assert!(modify_lever_response.margin_delta == i257_new(10000_000_000, false));
+        assert!(modify_lever_response.collateral_delta == I257Trait::new(10110_000_000, false));
+        assert!(modify_lever_response.debt_delta > I257Trait::new(0, false));
+        assert!(modify_lever_response.margin_delta == I257Trait::new(10000_000_000, false));
 
         let (_, collateral, _) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
@@ -1238,7 +1195,7 @@ mod Test_896150_Multiply {
             lever_swap_amount_1
                 + lever_swap_amount_2
                 + lever_swap_amount_3
-                + lever_swap_amount_4 == 110_000_000
+                + lever_swap_amount_4 == 110_000_000,
         );
         assert!(
             collateral
@@ -1246,11 +1203,11 @@ mod Test_896150_Multiply {
                 + lever_swap_amount_1
                 + lever_swap_amount_2
                 + lever_swap_amount_3
-                + lever_swap_amount_4
+                + lever_swap_amount_4,
         );
 
         assert!(
-            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into()
+            usdc.balanceOf(user) == usdc_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -1259,16 +1216,9 @@ mod Test_896150_Multiply {
     #[should_panic(expected: "limit-amount-exceeded")]
     #[fork("Mainnet")]
     fn test_modify_lever_multi_swap_limit_amount_exceeded() {
-        let TestConfig { singleton,
-        multiply,
-        pool_id,
-        pool_key_3,
-        pool_key_4,
-        eth,
-        usdc,
-        user,
-        .. } =
-            setup();
+        let TestConfig {
+            singleton, multiply, pool_id, pool_key_3, pool_key_4, eth, usdc, user, ..,
+        } = setup();
 
         usdc.approve(multiply.contract_address, 10000_000_000.into());
         singleton.modify_delegation(pool_id, multiply.contract_address, true);
@@ -1287,25 +1237,25 @@ mod Test_896150_Multiply {
                         RouteNode {
                             pool_key: pool_key_3,
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: pool_key_4,
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((100_000_000).try_into().unwrap(), true)
+                        amount: i129_new((100_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 10000000000000000, // 0.01 ETH
+            lever_swap_limit_amount: 10000000000000000 // 0.01 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -1332,20 +1282,20 @@ mod Test_896150_Multiply {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((110_000_000).try_into().unwrap(), true)
+                        amount: i129_new((110_000_000).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            lever_swap_limit_amount: 35000000000000000, // 0.035 ETH
+            lever_swap_limit_amount: 35000000000000000 // 0.035 ETH
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -1364,114 +1314,108 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
                                 tick_spacing: 1000,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: 0x446634e28eeaa431ae12ec1659450,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
-                    token_amount: TokenAmount {
-                        token: eth.contract_address, amount: Zero::zero(),
-                    },
+                    token_amount: TokenAmount { token: eth.contract_address, amount: Zero::zero() },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: 0x307e81d097153647a82829cfa5d7901,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793ee
-                                >(),
-                                token1: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
+                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0xc49ba5e353f7d00000000000000000,
                                 tick_spacing: 354892,
-                                extension: contract_address_const::<
-                                    0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fdc
-                                >()
+                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fd
+                                    .try_into()
+                                    .unwrap(),
                             },
                             sqrt_ratio_limit: 0x131b02323b1a000e3,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793ee
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0xc49ba5e353f7d00000000000000000,
                                 tick_spacing: 5982,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: 0x9b876e7f2023a3f55e14d63d,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
-                    token_amount: TokenAmount {
-                        token: eth.contract_address, amount: Zero::zero(),
-                    },
+                    token_amount: TokenAmount { token: eth.contract_address, amount: Zero::zero() },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: 0x307ddc74b2248a73b1f19d7430afe18,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
                                 tick_spacing: 1000,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: 0xd48a866dfb39cd5e9d7687efb52,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
-                    token_amount: TokenAmount {
-                        token: eth.contract_address, amount: Zero::zero(),
-                    },
+                    token_amount: TokenAmount { token: eth.contract_address, amount: Zero::zero() },
                 },
             ],
             lever_swap_limit_amount: 110_000_000
@@ -1480,11 +1424,11 @@ mod Test_896150_Multiply {
             withdraw_swap: array![],
             withdraw_swap_limit_amount: 0,
             withdraw_swap_weights: array![],
-            close_position: true
+            close_position: true,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone())
+            action: ModifyLeverAction::DecreaseLever(decrease_lever_params.clone()),
         };
 
         let (_, collateral, debt) = singleton
@@ -1492,9 +1436,9 @@ mod Test_896150_Multiply {
 
         let modify_lever_response = multiply.modify_lever(modify_lever_params);
 
-        assert!(modify_lever_response.collateral_delta == i257_new(collateral, true));
-        assert!(modify_lever_response.debt_delta == i257_new(debt, true));
-        assert!(modify_lever_response.margin_delta <= i257_new(9999_000_000, true));
+        assert!(modify_lever_response.collateral_delta == I257Trait::new(collateral, true));
+        assert!(modify_lever_response.debt_delta == I257Trait::new(debt, true));
+        assert!(modify_lever_response.margin_delta <= I257Trait::new(9999_000_000, true));
 
         let (position, collateral, debt) = singleton
             .position(pool_id, usdc.contract_address, eth.contract_address, user);
@@ -1504,7 +1448,7 @@ mod Test_896150_Multiply {
         assert!(debt == 0);
 
         assert!(
-            usdc.balanceOf(user) >= user_balance_before + decrease_lever_params.sub_margin.into()
+            usdc.balanceOf(user) >= user_balance_before + decrease_lever_params.sub_margin.into(),
         );
     }
 }

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -7,18 +7,16 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_896150_Multiply {
-    use alexandria_math::i257::{I257Trait, i257};
+    use alexandria_math::i257::I257Trait;
     use core::num::traits::Zero;
-    use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters};
+    use ekubo::interfaces::core::ICoreDispatcher;
     use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use ekubo::types::i129::i129Trait;
     use ekubo::types::keys::PoolKey;
     use snforge_std::{CheatSpan, cheat_caller_address, load};
-    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
-    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use starknet::{ContractAddress, get_contract_address};
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
     use vesu::test::setup_v2::deploy_with_args;
-    use vesu::units::{SCALE, SCALE_128};
+    use vesu::units::SCALE_128;
     use vesu_periphery::i129_new;
     use vesu_periphery::multiply::{
         DecreaseLeverParams, IMultiplyDispatcher, IMultiplyDispatcherTrait, IncreaseLeverParams,

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -50,7 +50,7 @@ mod Test_896150_Multiply {
                 .unwrap(),
         };
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };
@@ -67,17 +67,17 @@ mod Test_896150_Multiply {
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                 .try_into()
                 .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                 .try_into()
                 .unwrap(),
         };
@@ -1065,7 +1065,7 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: usdc.contract_address,
@@ -1078,7 +1078,7 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: eth.contract_address,
@@ -1099,7 +1099,7 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: usdc.contract_address,
@@ -1112,7 +1112,7 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: eth.contract_address,
@@ -1135,7 +1135,7 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: usdc.contract_address,
@@ -1148,7 +1148,7 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 token1: eth.contract_address,
@@ -1312,10 +1312,10 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
@@ -1332,10 +1332,10 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
@@ -1350,7 +1350,7 @@ mod Test_896150_Multiply {
                                 token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token1: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
                                 fee: 0xc49ba5e353f7d00000000000000000,
@@ -1367,7 +1367,7 @@ mod Test_896150_Multiply {
                                 token0: 0x3b405a98c9e795d427fe82cdeeeed803f221b52471e3a757574a2b4180793e
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0xc49ba5e353f7d00000000000000000,
@@ -1384,10 +1384,10 @@ mod Test_896150_Multiply {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
@@ -1399,10 +1399,10 @@ mod Test_896150_Multiply {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -45,7 +45,7 @@ mod Test_896150_Multiply {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -62,7 +62,7 @@ mod Test_896150_Multiply {
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply.cairo
+++ b/tests/test_multiply.cairo
@@ -1118,7 +1118,7 @@ mod Test_896150_Multiply {
                                 token1: eth.contract_address,
                                 fee: 0x28f5c28f5c28f5c28f5c28f5c28f5c2,
                                 tick_spacing: 354892,
-                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fd
+                                extension: 0x43e4f09c32d13d43a880e85f69f7de93ceda62d6cf2581a582c6db635548fdc
                                     .try_into()
                                     .unwrap(),
                             },

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IStarkgateERC20<TContractState> {
@@ -7,34 +7,27 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_974640_Multiply4626 {
-    use snforge_std::{start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load};
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address
+    use alexandria_math::i257::{I257Trait, i257};
+    use core::num::traits::Zero;
+    use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters};
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use ekubo::types::i129::i129Trait;
+    use ekubo::types::keys::PoolKey;
+    use snforge_std::{CheatSpan, cheat_caller_address, load};
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
+    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use vesu::extension::default_extension_po_v2::{
+        IDefaultExtensionPOV2Dispatcher, IDefaultExtensionPOV2DispatcherTrait,
     };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait}, test::setup::deploy_with_args,
-        common::{i257, i257_new},
-        extension::default_extension_po::{
-            IDefaultExtensionDispatcher, IDefaultExtensionDispatcherTrait
-        }
-    };
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::setup_v2::deploy_with_args;
+    use vesu::units::{SCALE, SCALE_128};
+    use vesu_periphery::i129_new;
     use vesu_periphery::multiply4626::{
-        IMultiply4626Dispatcher, IMultiply4626DispatcherTrait, ModifyLeverParams,
-        IncreaseLeverParams, ModifyLeverAction, I4626Dispatcher, I4626DispatcherTrait
+        I4626Dispatcher, I4626DispatcherTrait, IMultiply4626Dispatcher,
+        IMultiply4626DispatcherTrait, IncreaseLeverParams, ModifyLeverAction, ModifyLeverParams,
     };
-    use vesu_periphery::swap::{RouteNode, TokenAmount, Swap};
-
+    use vesu_periphery::swap::{RouteNode, Swap, TokenAmount};
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
     const MIN_SQRT_RATIO_LIMIT: u256 = 18446748437148339061;
@@ -42,8 +35,8 @@ mod Test_974640_Multiply4626 {
 
     struct TestConfig {
         ekubo: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
-        extension: IDefaultExtensionDispatcher,
+        singleton: ISingletonV2Dispatcher,
+        extension: IDefaultExtensionPOV2Dispatcher,
         multiply: IMultiply4626Dispatcher,
         pool_id: felt252,
         pool_key: PoolKey,
@@ -61,57 +54,57 @@ mod Test_974640_Multiply4626 {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: contract_address_const::<
-                0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
-            >()
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+                .try_into()
+                .unwrap(),
         };
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
         let multiply = IMultiply4626Dispatcher {
             contract_address: deploy_with_args(
                 "Multiply4626",
-                array![ekubo.contract_address.into(), singleton.contract_address.into()]
-            )
+                array![ekubo.contract_address.into(), singleton.contract_address.into()],
+            ),
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-            >()
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+                .try_into()
+                .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-            >()
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                .try_into()
+                .unwrap(),
         };
         let xstrk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a
-            >()
+            contract_address: 0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b
+                .try_into()
+                .unwrap(),
         };
         let sstrk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x0356f304b154d29d2a8fe22f1cb9107a9b564a733cf6b4cc47fd121ac1af90c9
-            >()
+            contract_address: 0x0356f304b154d29d2a8fe22f1cb9107a9b564a733cf6b4cc47fd121ac1af90
+                .try_into()
+                .unwrap(),
         };
 
         let pool_id = 2345856225134458665876812536882617294246962319062565703131100435311373119841;
 
-        let extension = IDefaultExtensionDispatcher {
-            contract_address: singleton.extension(pool_id)
+        let extension = IDefaultExtensionPOV2Dispatcher {
+            contract_address: singleton.extension(pool_id),
         };
 
         let pool_key = PoolKey {
@@ -119,7 +112,7 @@ mod Test_974640_Multiply4626 {
             token1: usdc.contract_address,
             fee: 170141183460469235273462165868118016,
             tick_spacing: 1000,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_2 = PoolKey {
@@ -127,7 +120,7 @@ mod Test_974640_Multiply4626 {
             token1: usdt.contract_address,
             fee: 8507159232437450533281168781287096,
             tick_spacing: 25,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_3 = PoolKey {
@@ -135,7 +128,7 @@ mod Test_974640_Multiply4626 {
             token1: usdc.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_4 = PoolKey {
@@ -143,24 +136,22 @@ mod Test_974640_Multiply4626 {
             token1: eth.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let user = get_contract_address();
 
         let loaded = load(strk.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(strk.contract_address), minter);
+        cheat_caller_address(strk.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: strk.contract_address }
             .permissioned_mint(user, 10000 * SCALE);
-        stop_prank(CheatTarget::One(strk.contract_address));
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdc.contract_address), minter);
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 10000_000_000);
-        stop_prank(CheatTarget::One(usdc.contract_address));
 
         let test_config = TestConfig {
             ekubo,
@@ -178,7 +169,7 @@ mod Test_974640_Multiply4626 {
             strk,
             xstrk,
             sstrk,
-            user
+            user,
         };
 
         test_config
@@ -190,10 +181,11 @@ mod Test_974640_Multiply4626 {
     fn test_modify_lever_4626_xstrk_no_flash_loan() {
         let TestConfig { singleton, extension, multiply, pool_id, strk, xstrk, user, .. } = setup();
 
-        start_prank(CheatTarget::One(extension.contract_address), extension.pool_owner(pool_id));
+        cheat_caller_address(
+            extension.contract_address, extension.pool_owner(pool_id), CheatSpan::TargetCalls(1),
+        );
         extension
             .set_debt_cap(pool_id, xstrk.contract_address, strk.contract_address, 10000000 * SCALE);
-        stop_prank(CheatTarget::One(extension.contract_address));
 
         let strk_balance_before = strk.balanceOf(user);
 
@@ -208,11 +200,11 @@ mod Test_974640_Multiply4626 {
             add_margin_is_wrapped: false,
             margin_swap: array![],
             margin_swap_limit_amount: 0,
-            lever_amount: 0
+            lever_amount: 0,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -222,7 +214,7 @@ mod Test_974640_Multiply4626 {
 
         assert!(debt == 0);
         assert!(
-            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into()
+            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -230,12 +222,15 @@ mod Test_974640_Multiply4626 {
     // #[available_gas(20000000)]
     // #[fork("Mainnet")]
     // fn test_modify_lever_4626_sstrk_no_flash_loan() {
-    //     let TestConfig { singleton, extension, multiply, pool_id, strk, sstrk, user, .. } = setup();
+    //     let TestConfig { singleton, extension, multiply, pool_id, strk, sstrk, user, .. } =
+    //     setup();
 
-    //     start_prank(CheatTarget::One(extension.contract_address), extension.pool_owner(pool_id));
+    //     cheat_caller_address(CheatSpan::TargetCalls(1 (extension.contract_address),
+    //     extension.pool_owner(pool_id));
     //     extension
-    //         .set_debt_cap(pool_id, sstrk.contract_address, strk.contract_address, 10000000 * SCALE);
-    //     stop_prank(CheatTarget::One(extension.contract_address));
+    //         .set_debt_cap(pool_id, sstrk.contract_address, strk.contract_address, 10000000 *
+    //         SCALE);
+    //     stop_prank(CheatSpan::TargetCalls(1 (extension.contract_address));
 
     //     let strk_balance_before = strk.balanceOf(user);
 
@@ -273,10 +268,11 @@ mod Test_974640_Multiply4626 {
     fn test_modify_lever_4626_xstrk() {
         let TestConfig { singleton, extension, multiply, pool_id, strk, xstrk, user, .. } = setup();
 
-        start_prank(CheatTarget::One(extension.contract_address), extension.pool_owner(pool_id));
+        cheat_caller_address(
+            extension.contract_address, extension.pool_owner(pool_id), CheatSpan::TargetCalls(1),
+        );
         extension
             .set_debt_cap(pool_id, xstrk.contract_address, strk.contract_address, 10000000 * SCALE);
-        stop_prank(CheatTarget::One(extension.contract_address));
 
         let strk_balance_before = strk.balanceOf(user);
 
@@ -291,11 +287,11 @@ mod Test_974640_Multiply4626 {
             add_margin_is_wrapped: false,
             margin_swap: array![],
             margin_swap_limit_amount: 0,
-            lever_amount: 400 * SCALE_128
+            lever_amount: 400 * SCALE_128,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -305,7 +301,7 @@ mod Test_974640_Multiply4626 {
 
         assert!(debt - 1 == increase_lever_params.lever_amount.into());
         assert!(
-            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into()
+            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -313,13 +309,15 @@ mod Test_974640_Multiply4626 {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_modify_lever_4626_xstrk_margin_swap() {
-        let TestConfig { singleton, extension, multiply, pool_id, usdc, strk, xstrk, user, .. } =
-            setup();
+        let TestConfig {
+            singleton, extension, multiply, pool_id, usdc, strk, xstrk, user, ..,
+        } = setup();
 
-        start_prank(CheatTarget::One(extension.contract_address), extension.pool_owner(pool_id));
+        cheat_caller_address(
+            extension.contract_address, extension.pool_owner(pool_id), CheatSpan::TargetCalls(1),
+        );
         extension
             .set_debt_cap(pool_id, xstrk.contract_address, strk.contract_address, 10000000 * SCALE);
-        stop_prank(CheatTarget::One(extension.contract_address));
 
         let strk_balance_before = strk.balanceOf(user);
 
@@ -338,47 +336,47 @@ mod Test_974640_Multiply4626 {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
                                 tick_spacing: 1000,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((100_000_000).try_into().unwrap(), false)
+                        amount: i129_new((100_000_000).try_into().unwrap(), false),
                     },
-                }
+                },
             ],
             margin_swap_limit_amount: 0,
-            lever_amount: 400 * SCALE_128
+            lever_amount: 400 * SCALE_128,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);
@@ -388,7 +386,7 @@ mod Test_974640_Multiply4626 {
 
         assert!(debt - 1 == increase_lever_params.lever_amount.into());
         assert!(
-            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into()
+            strk.balanceOf(user) == strk_balance_before - increase_lever_params.add_margin.into(),
         );
     }
 
@@ -398,15 +396,17 @@ mod Test_974640_Multiply4626 {
     fn test_modify_lever_4626_xstrk_wrapped_margin() {
         let TestConfig { singleton, extension, multiply, pool_id, strk, xstrk, user, .. } = setup();
 
-        start_prank(CheatTarget::One(extension.contract_address), extension.pool_owner(pool_id));
+        cheat_caller_address(
+            extension.contract_address, extension.pool_owner(pool_id), CheatSpan::TargetCalls(1),
+        );
         extension
             .set_debt_cap(pool_id, xstrk.contract_address, strk.contract_address, 10000000 * SCALE);
-        stop_prank(CheatTarget::One(extension.contract_address));
 
         let strk_balance_before = strk.balanceOf(user);
 
         strk.approve(xstrk.contract_address, 100 * SCALE);
-        // println!("{}", I4626Dispatcher { contract_address: xstrk.contract_address }.deposit(100 * SCALE, user));
+        // println!("{}", I4626Dispatcher { contract_address: xstrk.contract_address }.deposit(100 *
+        // SCALE, user));
         I4626Dispatcher { contract_address: xstrk.contract_address }.deposit(100 * SCALE, user);
         xstrk.approve(multiply.contract_address, 100 * SCALE);
 
@@ -420,11 +420,11 @@ mod Test_974640_Multiply4626 {
             add_margin_is_wrapped: true,
             margin_swap: array![],
             margin_swap_limit_amount: 0,
-            lever_amount: 400 * SCALE_128
+            lever_amount: 400 * SCALE_128,
         };
 
         let modify_lever_params = ModifyLeverParams {
-            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone())
+            action: ModifyLeverAction::IncreaseLever(increase_lever_params.clone()),
         };
 
         multiply.modify_lever(modify_lever_params);

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -50,7 +50,7 @@ mod Test_974640_Multiply4626 {
 
     fn setup() -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -87,12 +87,12 @@ mod Test_974640_Multiply4626 {
                 .unwrap(),
         };
         let xstrk = IERC20Dispatcher {
-            contract_address: 0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b
+            contract_address: 0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a
                 .try_into()
                 .unwrap(),
         };
         let sstrk = IERC20Dispatcher {
-            contract_address: 0x0356f304b154d29d2a8fe22f1cb9107a9b564a733cf6b4cc47fd121ac1af90
+            contract_address: 0x0356f304b154d29d2a8fe22f1cb9107a9b564a733cf6b4cc47fd121ac1af90c9
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -67,7 +67,7 @@ mod Test_974640_Multiply4626 {
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -55,7 +55,7 @@ mod Test_974640_Multiply4626 {
                 .unwrap(),
         };
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };
@@ -72,17 +72,17 @@ mod Test_974640_Multiply4626 {
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                 .try_into()
                 .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                 .try_into()
                 .unwrap(),
         };
@@ -332,10 +332,10 @@ mod Test_974640_Multiply4626 {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
@@ -347,10 +347,10 @@ mod Test_974640_Multiply4626 {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,

--- a/tests/test_multiply4626.cairo
+++ b/tests/test_multiply4626.cairo
@@ -7,15 +7,11 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_974640_Multiply4626 {
-    use alexandria_math::i257::{I257Trait, i257};
-    use core::num::traits::Zero;
-    use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters};
+    use ekubo::interfaces::core::ICoreDispatcher;
     use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use ekubo::types::i129::i129Trait;
     use ekubo::types::keys::PoolKey;
     use snforge_std::{CheatSpan, cheat_caller_address, load};
-    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
-    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use starknet::{ContractAddress, get_contract_address};
     use vesu::extension::default_extension_po_v2::{
         IDefaultExtensionPOV2Dispatcher, IDefaultExtensionPOV2DispatcherTrait,
     };

--- a/tests/test_proxy.cairo
+++ b/tests/test_proxy.cairo
@@ -309,7 +309,7 @@ mod Test_Proxy {
                 pauser, extension.contract_address, selector!("set_shutdown_ltv_config"), true,
             );
 
-        cheat_caller_address((proxy.contract_address), pauser, CheatSpan::TargetCalls(1));
+        cheat_caller_address(proxy.contract_address, pauser, CheatSpan::TargetCalls(1));
 
         let mut ltv_config_serialized = array![];
         LTVConfig { max_ltv: 0 }.serialize(ref ltv_config_serialized);

--- a/tests/test_proxy.cairo
+++ b/tests/test_proxy.cairo
@@ -1,41 +1,24 @@
-use starknet::ContractAddress;
-
 #[cfg(test)]
 mod Test_Proxy {
-    use snforge_std::{start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load};
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address, account::Call
+    use ekubo::interfaces::erc20::IERC20Dispatcher;
+    use snforge_std::{CheatSpan, cheat_caller_address};
+    use starknet::account::Call;
+    use starknet::{ContractAddress, get_caller_address};
+    use vesu::data_model::LTVConfig;
+    use vesu::extension::components::position_hooks::ShutdownMode;
+    use vesu::extension::default_extension_po_v2::{
+        IDefaultExtensionPOV2Dispatcher, IDefaultExtensionPOV2DispatcherTrait,
     };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams, LTVConfig},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait}, test::setup::deploy_with_args,
-        common::{i257, i257_new},
-        extension::default_extension_po::{
-            IDefaultExtensionDispatcher, IDefaultExtensionDispatcherTrait, ShutdownMode
-        }
-    };
-    use vesu_periphery::multiply4626::{
-        IMultiply4626Dispatcher, IMultiply4626DispatcherTrait, ModifyLeverParams,
-        IncreaseLeverParams, ModifyLeverAction, I4626Dispatcher, I4626DispatcherTrait
-    };
-    use vesu_periphery::swap::{RouteNode, TokenAmount, Swap};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::setup_v2::deploy_with_args;
+    use vesu::units::SCALE;
     use vesu_periphery::proxy::{IProxyDispatcher, IProxyDispatcherTrait};
 
     struct TestConfig {
         eth: IERC20Dispatcher,
         usdc: IERC20Dispatcher,
-        singleton: ISingletonDispatcher,
-        extension: IDefaultExtensionDispatcher,
+        singleton: ISingletonV2Dispatcher,
+        extension: IDefaultExtensionPOV2Dispatcher,
         pool_id: felt252,
         manager: ContractAddress,
         pauser: ContractAddress,
@@ -44,40 +27,39 @@ mod Test_Proxy {
 
     fn setup() -> TestConfig {
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
 
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
 
         let pool_id = 2198503327643286920898110335698706244522220458610657370981979460625005526824;
 
-        let extension = IDefaultExtensionDispatcher {
-            contract_address: singleton.extension(pool_id)
+        let extension = IDefaultExtensionPOV2Dispatcher {
+            contract_address: singleton.extension(pool_id),
         };
 
         let manager = extension.pool_owner(pool_id);
-        let pauser = contract_address_const::<'0x1'>();
+        let pauser = '0x1'.try_into().unwrap();
 
         let proxy = IProxyDispatcher {
-            contract_address: deploy_with_args("Proxy", array![manager.into()])
+            contract_address: deploy_with_args("Proxy", array![manager.into()]),
         };
 
-        start_prank(CheatTarget::One(extension.contract_address), manager);
+        cheat_caller_address(extension.contract_address, manager, CheatSpan::TargetCalls(1));
         extension.set_pool_owner(pool_id, proxy.contract_address);
-        stop_prank(CheatTarget::One(extension.contract_address));
 
-        TestConfig { eth, usdc, singleton, extension, pool_id, manager, pauser, proxy, }
+        TestConfig { eth, usdc, singleton, extension, pool_id, manager, pauser, proxy }
     }
 
     #[test]
@@ -100,9 +82,8 @@ mod Test_Proxy {
 
         assert!(proxy.manager() != get_caller_address());
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy.set_manager(get_caller_address());
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         assert!(proxy.manager() == get_caller_address());
     }
@@ -117,7 +98,7 @@ mod Test_Proxy {
 
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("singleton"), true
+                pauser, extension.contract_address, selector!("singleton"), true,
             );
     }
 
@@ -130,35 +111,32 @@ mod Test_Proxy {
 
         assert!(!proxy.access_control(pauser, extension.contract_address, selector!("singleton")));
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("singleton"), true
+                pauser, extension.contract_address, selector!("singleton"), true,
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         assert!(proxy.access_control(pauser, extension.contract_address, selector!("singleton")));
 
-        start_prank(CheatTarget::One(proxy.contract_address), pauser);
+        cheat_caller_address(proxy.contract_address, pauser, CheatSpan::TargetCalls(1));
         proxy
             .proxy_call(
                 array![
                     Call {
                         to: extension.contract_address,
                         selector: selector!("singleton"),
-                        calldata: array![].span()
-                    }
+                        calldata: array![].span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("singleton"), false
+                pauser, extension.contract_address, selector!("singleton"), false,
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
     }
 
     #[test]
@@ -171,39 +149,36 @@ mod Test_Proxy {
 
         assert!(!proxy.access_control(pauser, extension.contract_address, selector!("singleton")));
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("singleton"), true
+                pauser, extension.contract_address, selector!("singleton"), true,
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         assert!(proxy.access_control(pauser, extension.contract_address, selector!("singleton")));
 
-        start_prank(CheatTarget::One(proxy.contract_address), pauser);
+        cheat_caller_address(proxy.contract_address, pauser, CheatSpan::TargetCalls(1));
         proxy
             .proxy_call(
                 array![
                     Call {
                         to: extension.contract_address,
                         selector: selector!("singleton"),
-                        calldata: array![].span()
-                    }
+                        calldata: array![].span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("singleton"), false
+                pauser, extension.contract_address, selector!("singleton"), false,
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         assert!(!proxy.access_control(pauser, extension.contract_address, selector!("singleton")));
 
-        start_prank(CheatTarget::One(proxy.contract_address), pauser);
+        cheat_caller_address(proxy.contract_address, pauser, CheatSpan::TargetCalls(1));
 
         proxy
             .proxy_call(
@@ -211,10 +186,10 @@ mod Test_Proxy {
                     Call {
                         to: extension.contract_address,
                         selector: selector!("singleton"),
-                        calldata: array![].span()
-                    }
+                        calldata: array![].span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
     }
 
@@ -225,7 +200,7 @@ mod Test_Proxy {
         let config = setup();
         let TestConfig { eth, usdc, extension, pool_id, manager, proxy, .. } = config;
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
 
         let mut ltv_config_serialized = array![];
         LTVConfig { max_ltv: 0 }.serialize(ref ltv_config_serialized);
@@ -234,11 +209,10 @@ mod Test_Proxy {
             pool_id, usdc.contract_address.into(), eth.contract_address.into(),
         ];
 
-        while !ltv_config_serialized
-            .is_empty() {
-                let item = ltv_config_serialized.pop_front().unwrap();
-                calldata.append(item);
-            };
+        while !ltv_config_serialized.is_empty() {
+            let item = ltv_config_serialized.pop_front().unwrap();
+            calldata.append(item);
+        }
 
         proxy
             .proxy_call(
@@ -246,19 +220,17 @@ mod Test_Proxy {
                     Call {
                         to: extension.contract_address,
                         selector: selector!("set_shutdown_ltv_config"),
-                        calldata: calldata.span()
-                    }
+                        calldata: calldata.span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         let shutdown_mode = extension
             .update_shutdown_status(pool_id, usdc.contract_address, eth.contract_address);
         assert!(shutdown_mode == ShutdownMode::Recovery);
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
 
         let mut ltv_config_serialized = array![];
         LTVConfig { max_ltv: SCALE.try_into().unwrap() }.serialize(ref ltv_config_serialized);
@@ -267,11 +239,10 @@ mod Test_Proxy {
             pool_id, usdc.contract_address.into(), eth.contract_address.into(),
         ];
 
-        while !ltv_config_serialized
-            .is_empty() {
-                let item = ltv_config_serialized.pop_front().unwrap();
-                calldata.append(item);
-            };
+        while !ltv_config_serialized.is_empty() {
+            let item = ltv_config_serialized.pop_front().unwrap();
+            calldata.append(item);
+        }
 
         proxy
             .proxy_call(
@@ -279,13 +250,11 @@ mod Test_Proxy {
                     Call {
                         to: extension.contract_address,
                         selector: selector!("set_shutdown_ltv_config"),
-                        calldata: calldata.span()
-                    }
+                        calldata: calldata.span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         let shutdown_mode = extension
             .update_shutdown_status(pool_id, usdc.contract_address, eth.contract_address);
@@ -300,7 +269,7 @@ mod Test_Proxy {
         let config = setup();
         let TestConfig { eth, usdc, extension, pool_id, pauser, proxy, .. } = config;
 
-        start_prank(CheatTarget::One(proxy.contract_address), pauser);
+        cheat_caller_address(proxy.contract_address, pauser, CheatSpan::TargetCalls(1));
 
         let mut ltv_config_serialized = array![];
         LTVConfig { max_ltv: 0 }.serialize(ref ltv_config_serialized);
@@ -309,11 +278,10 @@ mod Test_Proxy {
             pool_id, usdc.contract_address.into(), eth.contract_address.into(),
         ];
 
-        while !ltv_config_serialized
-            .is_empty() {
-                let item = ltv_config_serialized.pop_front().unwrap();
-                calldata.append(item);
-            };
+        while !ltv_config_serialized.is_empty() {
+            let item = ltv_config_serialized.pop_front().unwrap();
+            calldata.append(item);
+        }
 
         proxy
             .proxy_call(
@@ -321,13 +289,11 @@ mod Test_Proxy {
                     Call {
                         to: extension.contract_address,
                         selector: selector!("set_shutdown_ltv_config"),
-                        calldata: calldata.span()
-                    }
+                        calldata: calldata.span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-
-        stop_prank(CheatTarget::One(proxy.contract_address));
     }
 
     #[test]
@@ -337,14 +303,13 @@ mod Test_Proxy {
         let config = setup();
         let TestConfig { eth, usdc, extension, pool_id, manager, pauser, proxy, .. } = config;
 
-        start_prank(CheatTarget::One(proxy.contract_address), manager);
+        cheat_caller_address(proxy.contract_address, manager, CheatSpan::TargetCalls(1));
         proxy
             .set_caller_for_method(
-                pauser, extension.contract_address, selector!("set_shutdown_ltv_config"), true
+                pauser, extension.contract_address, selector!("set_shutdown_ltv_config"), true,
             );
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
-        start_prank(CheatTarget::One(proxy.contract_address), pauser);
+        cheat_caller_address((proxy.contract_address), pauser, CheatSpan::TargetCalls(1));
 
         let mut ltv_config_serialized = array![];
         LTVConfig { max_ltv: 0 }.serialize(ref ltv_config_serialized);
@@ -353,11 +318,10 @@ mod Test_Proxy {
             pool_id, usdc.contract_address.into(), eth.contract_address.into(),
         ];
 
-        while !ltv_config_serialized
-            .is_empty() {
-                let item = ltv_config_serialized.pop_front().unwrap();
-                calldata.append(item);
-            };
+        while !ltv_config_serialized.is_empty() {
+            let item = ltv_config_serialized.pop_front().unwrap();
+            calldata.append(item);
+        }
 
         proxy
             .proxy_call(
@@ -365,13 +329,11 @@ mod Test_Proxy {
                     Call {
                         to: extension.contract_address,
                         selector: selector!("set_shutdown_ltv_config"),
-                        calldata: calldata.span()
-                    }
+                        calldata: calldata.span(),
+                    },
                 ]
-                    .span()
+                    .span(),
             );
-
-        stop_prank(CheatTarget::One(proxy.contract_address));
 
         let shutdown_mode = extension
             .update_shutdown_status(pool_id, usdc.contract_address, eth.contract_address);

--- a/tests/test_proxy.cairo
+++ b/tests/test_proxy.cairo
@@ -27,7 +27,7 @@ mod Test_Proxy {
 
     fn setup() -> TestConfig {
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_proxy.cairo
+++ b/tests/test_proxy.cairo
@@ -32,13 +32,13 @@ mod Test_Proxy {
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
 
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_rebalance.cairo
+++ b/tests/test_rebalance.cairo
@@ -132,7 +132,7 @@ mod Test_896150_Rebalance {
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        cheat_caller_address((usdt.contract_address), minter, CheatSpan::TargetCalls(1));
+        cheat_caller_address(usdt.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10000_000_000);
 
@@ -661,7 +661,7 @@ mod Test_896150_Rebalance {
         let target_ltv_tolerance = (SCALE / 100).try_into().unwrap();
         let target_ltv_min_delta = target_ltv_tolerance + 1;
 
-        cheat_caller_address((rebalance.contract_address), user, CheatSpan::TargetCalls(1));
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,

--- a/tests/test_rebalance.cairo
+++ b/tests/test_rebalance.cairo
@@ -51,7 +51,7 @@ mod Test_896150_Rebalance {
                 .unwrap(),
         };
         let singleton = ISingletonV2Dispatcher {
-            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
                 .try_into()
                 .unwrap(),
         };
@@ -73,17 +73,17 @@ mod Test_896150_Rebalance {
                 .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                 .try_into()
                 .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
                 .try_into()
                 .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                 .try_into()
                 .unwrap(),
         };
@@ -559,10 +559,10 @@ mod Test_896150_Rebalance {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
@@ -574,10 +574,10 @@ mod Test_896150_Rebalance {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
@@ -597,10 +597,10 @@ mod Test_896150_Rebalance {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
@@ -841,10 +841,10 @@ mod Test_896150_Rebalance {
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
@@ -864,10 +864,10 @@ mod Test_896150_Rebalance {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                                     .try_into()
                                     .unwrap(),
-                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
                                     .try_into()
                                     .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,

--- a/tests/test_rebalance.cairo
+++ b/tests/test_rebalance.cairo
@@ -68,7 +68,7 @@ mod Test_896150_Rebalance {
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
                 .try_into()
                 .unwrap(),
         };

--- a/tests/test_rebalance.cairo
+++ b/tests/test_rebalance.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IStarkgateERC20<TContractState> {
@@ -7,32 +7,23 @@ trait IStarkgateERC20<TContractState> {
 
 #[cfg(test)]
 mod Test_896150_Rebalance {
-    use snforge_std::{
-        start_prank, stop_prank, start_warp, stop_warp, CheatTarget, load, prank, CheatSpan
+    use alexandria_math::i257::I257Trait;
+    use core::num::traits::Zero;
+    use ekubo::interfaces::core::ICoreDispatcher;
+    use ekubo::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use ekubo::types::keys::PoolKey;
+    use snforge_std::{CheatSpan, cheat_caller_address, load};
+    use starknet::{ContractAddress, get_contract_address};
+    use vesu::data_model::{Amount, AmountDenomination, AmountType, ModifyPositionParams};
+    use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
+    use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
+    use vesu::test::setup_v2::deploy_with_args;
+    use vesu::units::{SCALE, SCALE_128};
+    use vesu_periphery::i129_new;
+    use vesu_periphery::rebalance::{
+        IRebalanceDispatcher, IRebalanceDispatcherTrait, RebalanceParams,
     };
-    use starknet::{
-        ContractAddress, contract_address_const, get_block_timestamp, get_caller_address,
-        get_contract_address
-    };
-    use core::num::traits::{Zero};
-    use ekubo::{
-        interfaces::{
-            core::{ICoreDispatcher, ICoreDispatcherTrait, ILocker, SwapParameters},
-            erc20::{IERC20Dispatcher, IERC20DispatcherTrait}
-        },
-        types::{i129::{i129_new, i129Trait}, keys::{PoolKey},}
-    };
-    use vesu::{
-        units::{SCALE, SCALE_128},
-        data_model::{Amount, AmountType, AmountDenomination, ModifyPositionParams},
-        singleton::{ISingletonDispatcher, ISingletonDispatcherTrait},
-        extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait},
-        test::setup::deploy_with_args, common::{i257, i257_new}
-    };
-    use vesu_periphery::{
-        rebalance::{IRebalanceDispatcher, IRebalanceDispatcherTrait, RebalanceParams},
-        swap::{RouteNode, TokenAmount, Swap}
-    };
+    use vesu_periphery::swap::{RouteNode, Swap, TokenAmount};
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
     const MIN_SQRT_RATIO_LIMIT: u256 = 18446748437148339061;
@@ -40,7 +31,7 @@ mod Test_896150_Rebalance {
 
     struct TestConfig {
         ekubo: ICoreDispatcher,
-        singleton: ISingletonDispatcher,
+        singleton: ISingletonV2Dispatcher,
         rebalance: IRebalanceDispatcher,
         pool_id: felt252,
         pool_key: PoolKey,
@@ -55,14 +46,14 @@ mod Test_896150_Rebalance {
 
     fn setup(fee_rate: u128) -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: contract_address_const::<
-                0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
-            >()
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+                .try_into()
+                .unwrap(),
         };
-        let singleton = ISingletonDispatcher {
-            contract_address: contract_address_const::<
-                0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725ef
-            >()
+        let singleton = ISingletonV2Dispatcher {
+            contract_address: 0x2545b2e5d519fc230e9cd781046d3a64e092114f07e44771e0d719d148725e
+                .try_into()
+                .unwrap(),
         };
         let rebalance = IRebalanceDispatcher {
             contract_address: deploy_with_args(
@@ -71,30 +62,30 @@ mod Test_896150_Rebalance {
                     ekubo.contract_address.into(),
                     singleton.contract_address.into(),
                     get_contract_address().into(),
-                    fee_rate.into()
-                ]
-            )
+                    fee_rate.into(),
+                ],
+            ),
         };
 
         let eth = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-            >()
+            contract_address: 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004d
+                .try_into()
+                .unwrap(),
         };
         let usdc = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-            >()
+            contract_address: 0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368
+                .try_into()
+                .unwrap(),
         };
         let usdt = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8
-            >()
+            contract_address: 0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0f
+                .try_into()
+                .unwrap(),
         };
         let strk = IERC20Dispatcher {
-            contract_address: contract_address_const::<
-                0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-            >()
+            contract_address: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                .try_into()
+                .unwrap(),
         };
 
         let pool_id = 2198503327643286920898110335698706244522220458610657370981979460625005526824;
@@ -104,7 +95,7 @@ mod Test_896150_Rebalance {
             token1: usdc.contract_address,
             fee: 170141183460469235273462165868118016,
             tick_spacing: 1000,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_2 = PoolKey {
@@ -112,7 +103,7 @@ mod Test_896150_Rebalance {
             token1: usdt.contract_address,
             fee: 8507159232437450533281168781287096,
             tick_spacing: 25,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_3 = PoolKey {
@@ -120,7 +111,7 @@ mod Test_896150_Rebalance {
             token1: usdc.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let pool_key_4 = PoolKey {
@@ -128,27 +119,25 @@ mod Test_896150_Rebalance {
             token1: eth.contract_address,
             fee: 34028236692093847977029636859101184,
             tick_spacing: 200,
-            extension: contract_address_const::<0x0>()
+            extension: 0x0.try_into().unwrap(),
         };
 
         let user = get_contract_address();
 
         let loaded = load(usdc.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdc.contract_address), minter);
+        cheat_caller_address(usdc.contract_address, minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdc.contract_address }
             .permissioned_mint(user, 10000_000_000);
-        stop_prank(CheatTarget::One(usdc.contract_address));
 
         let loaded = load(usdt.contract_address, selector!("permitted_minter"), 1);
         let minter: ContractAddress = (*loaded[0]).try_into().unwrap();
-        start_prank(CheatTarget::One(usdt.contract_address), minter);
+        cheat_caller_address((usdt.contract_address), minter, CheatSpan::TargetCalls(1));
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10000_000_000);
-        stop_prank(CheatTarget::One(usdt.contract_address));
 
         rebalance.set_rebalancer(get_contract_address(), true);
-        rebalance.set_rebalancer(contract_address_const::<'0x1'>(), true);
+        rebalance.set_rebalancer('0x1'.try_into().unwrap(), true);
 
         let test_config = TestConfig {
             ekubo,
@@ -162,7 +151,7 @@ mod Test_896150_Rebalance {
             eth,
             usdc,
             usdt,
-            user
+            user,
         };
 
         test_config
@@ -175,8 +164,8 @@ mod Test_896150_Rebalance {
     fn test_rebalance_set_owner() {
         let TestConfig { rebalance, .. } = setup(0);
 
-        start_prank(
-            CheatTarget::One(rebalance.contract_address), contract_address_const::<'0x3'>()
+        cheat_caller_address(
+            rebalance.contract_address, '0x3'.try_into().unwrap(), CheatSpan::TargetCalls(1),
         );
         rebalance.set_owner(get_contract_address());
     }
@@ -188,8 +177,8 @@ mod Test_896150_Rebalance {
     fn test_rebalance_set_rebalancer() {
         let TestConfig { rebalance, .. } = setup(0);
 
-        start_prank(
-            CheatTarget::One(rebalance.contract_address), contract_address_const::<'0x3'>()
+        cheat_caller_address(
+            rebalance.contract_address, '0x3'.try_into().unwrap(), CheatSpan::TargetCalls(1),
         );
         rebalance.set_rebalancer(get_contract_address(), true);
     }
@@ -208,14 +197,13 @@ mod Test_896150_Rebalance {
             user,
             rebalance_swap: array![],
             rebalance_swap_limit_amount: 0,
-            fee_recipient: Zero::zero()
+            fee_recipient: Zero::zero(),
         };
 
-        start_prank(
-            CheatTarget::One(rebalance.contract_address), contract_address_const::<'0x2'>()
+        cheat_caller_address(
+            rebalance.contract_address, '0x2'.try_into().unwrap(), CheatSpan::TargetCalls(1),
         );
         rebalance.rebalance_position(rebalance_params.clone());
-        stop_prank(CheatTarget::One(rebalance.contract_address));
     }
 
     #[test]
@@ -229,7 +217,7 @@ mod Test_896150_Rebalance {
         let target_ltv_tolerance = 0;
         let target_ltv_min_delta = 1;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -237,9 +225,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -253,11 +240,11 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Default::default(),
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -269,7 +256,7 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, collateral_delta, debt_delta) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -280,18 +267,18 @@ mod Test_896150_Rebalance {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((collateral_delta.abs).try_into().unwrap(), true)
+                        amount: i129_new((collateral_delta.abs()).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            rebalance_swap_limit_amount: debt_delta.abs.try_into().unwrap()
+            rebalance_swap_limit_amount: debt_delta.abs().try_into().unwrap()
                 + (SCALE / 10).try_into().unwrap(), // 3 ETH
-            fee_recipient: Zero::zero()
+            fee_recipient: Zero::zero(),
         };
 
         rebalance.rebalance_position(rebalance_params.clone());
@@ -308,7 +295,7 @@ mod Test_896150_Rebalance {
         let target_ltv_tolerance = (SCALE / 100).try_into().unwrap();
         let target_ltv_min_delta = SCALE_128;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -316,9 +303,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -332,11 +318,11 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Default::default(),
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -348,7 +334,7 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, collateral_delta, debt_delta) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -359,18 +345,18 @@ mod Test_896150_Rebalance {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((collateral_delta.abs).try_into().unwrap(), true)
+                        amount: i129_new((collateral_delta.abs()).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            rebalance_swap_limit_amount: debt_delta.abs.try_into().unwrap()
+            rebalance_swap_limit_amount: debt_delta.abs().try_into().unwrap()
                 + (SCALE / 10).try_into().unwrap(), // 3 ETH
-            fee_recipient: Zero::zero()
+            fee_recipient: Zero::zero(),
         };
 
         rebalance.rebalance_position(rebalance_params.clone());
@@ -380,15 +366,15 @@ mod Test_896150_Rebalance {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_rebalance_increase_with_fee() {
-        let TestConfig { singleton, rebalance, pool_id, pool_key, eth, usdc, user, .. } = setup(
-            SCALE_128 / 100
-        );
+        let TestConfig {
+            singleton, rebalance, pool_id, pool_key, eth, usdc, user, ..,
+        } = setup(SCALE_128 / 100);
 
         let target_ltv = (SCALE / 2).try_into().unwrap();
         let target_ltv_tolerance = SCALE_128 / 100;
         let target_ltv_min_delta = target_ltv_tolerance + 1;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -396,9 +382,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -412,11 +397,11 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Default::default(),
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -430,9 +415,9 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, collateral_delta, debt_delta) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
-        let rebalancer = contract_address_const::<'0x1'>();
+        let rebalancer = '0x1'.try_into().unwrap();
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -443,23 +428,22 @@ mod Test_896150_Rebalance {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((collateral_delta.abs).try_into().unwrap(), true)
+                        amount: i129_new((collateral_delta.abs()).try_into().unwrap(), true),
                     },
-                }
+                },
             ],
-            rebalance_swap_limit_amount: debt_delta.abs.try_into().unwrap()
+            rebalance_swap_limit_amount: debt_delta.abs().try_into().unwrap()
                 + (SCALE / 10).try_into().unwrap(), // 3 ETH
-            fee_recipient: rebalancer
+            fee_recipient: rebalancer,
         };
 
-        prank(CheatTarget::One(rebalance.contract_address), rebalancer, CheatSpan::TargetCalls(1));
+        cheat_caller_address(rebalance.contract_address, rebalancer, CheatSpan::TargetCalls(1));
         rebalance.rebalance_position(rebalance_params.clone());
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         let (collateral_asset_config, _) = singleton.asset_config(pool_id, usdc.contract_address);
         let (debt_asset_config, _) = singleton.asset_config(pool_id, eth.contract_address);
@@ -489,15 +473,15 @@ mod Test_896150_Rebalance {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_rebalance_increase_with_fee_split_swap() {
-        let TestConfig { singleton, rebalance, pool_id, eth, usdc, user, .. } = setup(
-            SCALE_128 / 100
-        );
+        let TestConfig {
+            singleton, rebalance, pool_id, eth, usdc, user, ..,
+        } = setup(SCALE_128 / 100);
 
         let target_ltv = (SCALE / 2).try_into().unwrap();
         let target_ltv_tolerance = (SCALE / 100).try_into().unwrap();
         let target_ltv_min_delta = target_ltv_tolerance + 1;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -505,9 +489,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -521,11 +504,11 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Default::default(),
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -539,9 +522,9 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, _, debt_delta) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
-        let rebalancer = contract_address_const::<'0x1'>();
+        let rebalancer = '0x1'.try_into().unwrap();
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -553,95 +536,94 @@ mod Test_896150_Rebalance {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
-                                fee: 0x20c49ba5e353f80000000000000000,
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
+                                    .try_into()
+                                    .unwrap(),
+                                fee: 0x20c49ba5e353f80000000000000000.try_into().unwrap(),
                                 tick_spacing: 1000,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((7421874999).try_into().unwrap(), true)
-                    }
+                        amount: i129_new((7421874999).try_into().unwrap(), true),
+                    },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x20c49ba5e353f80000000000000000,
                                 tick_spacing: 1000,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((2500000000).try_into().unwrap(), true)
-                    }
+                        amount: i129_new((2500000000).try_into().unwrap(), true),
+                    },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 3
-                        }
+                            skip_ahead: 3,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((78125000).try_into().unwrap(), true)
-                    }
+                        amount: i129_new((78125000).try_into().unwrap(), true),
+                    },
                 },
             ],
-            rebalance_swap_limit_amount: debt_delta.abs.try_into().unwrap()
+            rebalance_swap_limit_amount: debt_delta.abs().try_into().unwrap()
                 + (SCALE / 10).try_into().unwrap(), // 3 ETH
-            fee_recipient: rebalancer
+            fee_recipient: rebalancer,
         };
 
-        prank(CheatTarget::One(rebalance.contract_address), rebalancer, CheatSpan::TargetCalls(1));
+        cheat_caller_address(rebalance.contract_address, rebalancer, CheatSpan::TargetCalls(1));
         rebalance.rebalance_position(rebalance_params.clone());
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         let (collateral_asset_config, _) = singleton.asset_config(pool_id, usdc.contract_address);
         let (debt_asset_config, _) = singleton.asset_config(pool_id, eth.contract_address);
@@ -671,15 +653,15 @@ mod Test_896150_Rebalance {
     #[available_gas(20000000)]
     #[fork("Mainnet")]
     fn test_rebalance_decrease_with_fee() {
-        let TestConfig { singleton, rebalance, pool_id, pool_key, eth, usdc, user, .. } = setup(
-            SCALE_128 / 100
-        );
+        let TestConfig {
+            singleton, rebalance, pool_id, pool_key, eth, usdc, user, ..,
+        } = setup(SCALE_128 / 100);
 
         let target_ltv = (SCALE / 4).try_into().unwrap();
         let target_ltv_tolerance = (SCALE / 100).try_into().unwrap();
         let target_ltv_min_delta = target_ltv_tolerance + 1;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address((rebalance.contract_address), user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -687,9 +669,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -703,15 +684,15 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
                         value: (146 * SCALE / 100).into() // 1.46 ETH
                     },
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -725,9 +706,9 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, collateral_delta, _) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
-        let rebalancer = contract_address_const::<'0x1'>();
+        let rebalancer = '0x1'.try_into().unwrap();
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -738,22 +719,21 @@ mod Test_896150_Rebalance {
                 Swap {
                     route: array![
                         RouteNode {
-                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0
-                        }
+                            pool_key, sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT, skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new(collateral_delta.abs.try_into().unwrap(), false)
-                    }
-                }
+                        amount: i129_new(collateral_delta.abs().try_into().unwrap(), false),
+                    },
+                },
             ],
             rebalance_swap_limit_amount: 0,
-            fee_recipient: rebalancer
+            fee_recipient: rebalancer,
         };
 
-        prank(CheatTarget::One(rebalance.contract_address), rebalancer, CheatSpan::TargetCalls(1));
+        cheat_caller_address(rebalance.contract_address, rebalancer, CheatSpan::TargetCalls(1));
         rebalance.rebalance_position(rebalance_params.clone());
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         let (collateral_asset_config, _) = singleton.asset_config(pool_id, usdc.contract_address);
         let (debt_asset_config, _) = singleton.asset_config(pool_id, eth.contract_address);
@@ -789,7 +769,7 @@ mod Test_896150_Rebalance {
         let target_ltv_tolerance = (SCALE / 10).try_into().unwrap();
         let target_ltv_min_delta = target_ltv_tolerance + 1;
 
-        start_prank(CheatTarget::One(rebalance.contract_address), user);
+        cheat_caller_address(rebalance.contract_address, user, CheatSpan::TargetCalls(1));
         rebalance
             .set_target_ltv_config(
                 pool_id,
@@ -797,9 +777,8 @@ mod Test_896150_Rebalance {
                 eth.contract_address,
                 target_ltv,
                 target_ltv_tolerance,
-                target_ltv_min_delta
+                target_ltv_min_delta,
             );
-        stop_prank(CheatTarget::One(rebalance.contract_address));
 
         usdc.approve(singleton.contract_address, 10000_000_000.into());
 
@@ -813,15 +792,15 @@ mod Test_896150_Rebalance {
                     collateral: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
-                        value: 10000_000_000.into()
+                        value: 10000_000_000.into(),
                     },
                     debt: Amount {
                         amount_type: AmountType::Delta,
                         denomination: AmountDenomination::Assets,
                         value: (146 * SCALE / 100).into() // 1.46 ETH
                     },
-                    data: ArrayTrait::new().span()
-                }
+                    data: ArrayTrait::new().span(),
+                },
             );
 
         let (_, collateral, debt) = singleton
@@ -835,7 +814,7 @@ mod Test_896150_Rebalance {
 
         let (_, delta_usd, _, _) = rebalance
             .delta(pool_id, usdc.contract_address, eth.contract_address, user);
-        assert!(delta_usd.abs != 0);
+        assert!(delta_usd.abs() != 0);
 
         let rebalance_params = RebalanceParams {
             pool_id,
@@ -847,66 +826,66 @@ mod Test_896150_Rebalance {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
-                                >(),
-                                token1: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
+                                token0: 0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MIN_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
-                        }
+                            skip_ahead: 0,
+                        },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((2691187944).try_into().unwrap(), false)
-                    }
+                        amount: i129_new((2691187944).try_into().unwrap(), false),
+                    },
                 },
                 Swap {
                     route: array![
                         RouteNode {
                             pool_key: PoolKey {
-                                token0: contract_address_const::<
-                                    0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-                                >(),
-                                token1: contract_address_const::<
-                                    0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8
-                                >(),
+                                token0: 0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc
+                                    .try_into()
+                                    .unwrap(),
+                                token1: 0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a
+                                    .try_into()
+                                    .unwrap(),
                                 fee: 0x68db8bac710cb4000000000000000,
                                 tick_spacing: 200,
-                                extension: contract_address_const::<0x0>()
+                                extension: 0x0.try_into().unwrap(),
                             },
                             sqrt_ratio_limit: MAX_SQRT_RATIO_LIMIT,
-                            skip_ahead: 0
+                            skip_ahead: 0,
                         },
                     ],
                     token_amount: TokenAmount {
                         token: usdc.contract_address,
-                        amount: i129_new((200000000).try_into().unwrap(), false)
-                    }
+                        amount: i129_new((200000000).try_into().unwrap(), false),
+                    },
                 },
             ],
             rebalance_swap_limit_amount: 0,
-            fee_recipient: Zero::zero()
+            fee_recipient: Zero::zero(),
         };
 
         rebalance.rebalance_position(rebalance_params.clone());

--- a/tests/test_rebalance.cairo
+++ b/tests/test_rebalance.cairo
@@ -46,7 +46,7 @@ mod Test_896150_Rebalance {
 
     fn setup(fee_rate: u128) -> TestConfig {
         let ekubo = ICoreDispatcher {
-            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b
+            contract_address: 0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b
                 .try_into()
                 .unwrap(),
         };


### PR DESCRIPTION
Upgrading Starknet version to 2.11.4 and latest edition
Here are the changes I had to make: 
- position_list.cairo: `*self.collateral_asset == contract_address_const::<''>()` updated to use `is_zero()`
- as `i129_new` isn't public in ekubo I copy pasted it
- Updating Vesu's new interfaces (V2)
- `.abs` updated to `.abs()`
- Updating LegacyMap to Map
- `i257_new` to `I257Trait::new`
- swap.cairo: update the logic in `assert_matching_token_amounts(...)` since the compiler was complaining with the if else, now using `if let Option(...`

The rest is formatting changes done automatically

I also started working on **Separating owner from manager**  