### PR TITLE
2. Asset list

### DIFF
--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -235,19 +235,24 @@ pub mod ManagedVault {
             assert!(price_sell.is_valid, "price-sell-invalid");
             assert!(price_buy.is_valid, "price-buy-invalid");
             assert!(price_sell.value != 0, "price-sell-zero");
-            assert!(price_buy.value != 0, "price-out-zero");
-            // TODO Protect this with a read-only lock? Since owner has to approve the asset, is it
-            // even useful?
+            assert!(price_buy.value != 0, "price-buy-zero");
+            // TODO Protect this with a read-only lock?
+            // Since owner has to approve the asset, is it even useful?
+            // TODO Configurable slippage
+            let slippage_decimals = 4;
+            let slippage_bps = 95_00; // 95% of the price
             let sell_token_decimals = IERC20Dispatcher { contract_address: sell_token }.decimals();
-            let buy_token_decimals = IERC20Dispatcher { contract_address: buy_token }.decimals();
-            // TODO slippage
+            let buy_token_decimals = IERC20Dispatcher { contract_address: buy_token }
+                .decimals()
+                .into();
+            let decimals_total = sell_token_decimals.into() + slippage_decimals;
             // TODO handle rounding: has to be Ceil in this case
-            let min_bought_amount = if sell_token_decimals > buy_token_decimals {
-                let scale_div = pow_10(sell_token_decimals.into() - buy_token_decimals.into());
-                (sell_amount * price_sell.value) / (price_buy.value * scale_div)
+            let min_bought_amount = if decimals_total > buy_token_decimals {
+                let scale_div = pow_10(decimals_total - buy_token_decimals);
+                (sell_amount * price_sell.value * slippage_bps) / (price_buy.value * scale_div)
             } else {
-                let scale_mul = pow_10(buy_token_decimals.into() - sell_token_decimals.into());
-                (sell_amount * price_sell.value * scale_mul) / (price_buy.value)
+                let scale_mul = pow_10(buy_token_decimals - decimals_total);
+                (sell_amount * price_sell.value * scale_mul * slippage_bps) / (price_buy.value)
             };
             assert!(buy_amount >= min_bought_amount, "price-out-too-low");
         }
@@ -388,14 +393,15 @@ pub mod ManagedVault {
             self.assert_asset_approved(end_token);
             let start_token_dispatcher = IERC20Dispatcher { contract_address: start_token };
             let end_token_dispatcher = IERC20Dispatcher { contract_address: end_token };
-            let balance_start_before = start_token_dispatcher.balanceOf(get_contract_address());
-            let balance_end_before = end_token_dispatcher.balanceOf(get_contract_address());
+            // TODO Should there be a config to tell if asset is legacy or not?
+            let balance_start_before = start_token_dispatcher.balance_of(get_contract_address());
+            let balance_end_before = end_token_dispatcher.balance_of(get_contract_address());
             // Do the swap
             let _: () = call_core_with_callback(
                 self.ekubo_core.read(), @SwapParams { swap, limit_amount },
             );
-            let balance_start_after = start_token_dispatcher.balanceOf(get_contract_address());
-            let balance_end_after = end_token_dispatcher.balanceOf(get_contract_address());
+            let balance_start_after = start_token_dispatcher.balance_of(get_contract_address());
+            let balance_end_after = end_token_dispatcher.balance_of(get_contract_address());
             // Decide which token is in/out based on the balance change
             let is_selling_start_token = balance_start_after < balance_start_before;
             let (sell_amount, buy_amount, sell_token, buy_token) = if is_selling_start_token {

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -166,9 +166,7 @@ pub mod ManagedVault {
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
-        // Map of approved assets from the owner
-        // (asset, is_approved)
-        approved_asset: Map<ContractAddress, bool>,
+        // List of all approved assets and their configuration
         asset_config: Vec<AssetConfig>,
         // storage for the timestamp manager component
         #[substorage(v0)]
@@ -362,6 +360,7 @@ pub mod ManagedVault {
 
         fn modify_asset_configuration(ref self: ContractState, asset_configuration: AssetConfig) {
             self.assert_owner();
+            // TODO Handle asset removal
             for asset_index in 0..self.asset_config.len() {
                 let asset_config = self.asset_config[asset_index].read();
                 if asset_config.asset == asset_configuration.asset {

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -66,7 +66,7 @@ pub trait IManagedVault<TContractState> {
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
     fn modify_asset(ref self: TContractState, asset: ContractAddress, is_approved: bool);
-    fn get_asset_status(ref self: TContractState, asset: ContractAddress) -> bool;
+    fn is_asset_approved(self: @TContractState, asset: ContractAddress) -> bool;
 
     // User related functions
     fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
@@ -217,7 +217,7 @@ pub mod ManagedVault {
         }
 
         fn assert_asset_approved(self: @ContractState, asset: ContractAddress) {
-            assert!(self.asset_list.read(asset), "asset-not-approved");
+            assert!(self.is_asset_approved(asset), "asset-not-approved");
         }
 
         fn transfer_asset(
@@ -318,7 +318,7 @@ pub mod ManagedVault {
             self.asset_list.write(asset, is_approved);
         }
 
-        fn get_asset_status(ref self: ContractState, asset: ContractAddress) -> bool {
+        fn is_asset_approved(self: @ContractState, asset: ContractAddress) -> bool {
             self.asset_list.read(asset)
         }
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -94,6 +94,7 @@ pub struct SwapParams {
 pub struct AssetConfig {
     pub is_legacy: bool,
     // TODO Do we also need the extension?
+    // TODO Store scale?
     pub pool_id: felt252,
 }
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -65,6 +65,8 @@ pub trait IManagedVault<TContractState> {
         ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
+    fn modify_asset(ref self: TContractState, asset: ContractAddress, is_approved: bool);
+    fn get_asset_status(ref self: TContractState, asset: ContractAddress) -> bool;
 
     // User related functions
     fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
@@ -154,6 +156,8 @@ pub mod ManagedVault {
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
+        // TODO Name
+        asset_list: Map<ContractAddress, bool>,
         // storage for the timestamp manager component
         #[substorage(v0)]
         position_list: position_list_component::Storage,
@@ -211,6 +215,11 @@ pub mod ManagedVault {
         fn assert_owner(ref self: ContractState) {
             assert!(get_caller_address() == self.owner.read(), "caller-not-owner");
         }
+
+        fn assert_asset_approved(self: @ContractState, asset: ContractAddress) {
+            assert!(self.asset_list.read(asset), "asset-not-approved");
+        }
+
         fn transfer_asset(
             self: @ContractState, sender: ContractAddress, to: ContractAddress, amount: u256,
         ) {
@@ -228,6 +237,8 @@ pub mod ManagedVault {
         fn _swap(ref self: ContractState, params: SwapParams) {
             let core = self.ekubo_core.read();
             let (input_amount, output_amount) = swap(core, params.swap, params.limit_amount);
+            self.assert_asset_approved(input_amount.token);
+            self.assert_asset_approved(output_amount.token);
             handle_delta(core, output_amount.token, output_amount.amount, get_contract_address());
             handle_delta(core, input_amount.token, input_amount.amount, get_contract_address());
         }
@@ -301,6 +312,16 @@ pub mod ManagedVault {
             self.price_source.read()
         }
 
+
+        fn modify_asset(ref self: ContractState, asset: ContractAddress, is_approved: bool) {
+            self.assert_owner();
+            self.asset_list.write(asset, is_approved);
+        }
+
+        fn get_asset_status(ref self: ContractState, asset: ContractAddress) -> bool {
+            self.asset_list.read(asset)
+        }
+
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {
             self.assert_owner();
             self.redemption_timeout.write(timeout);
@@ -328,6 +349,10 @@ pub mod ManagedVault {
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
             assert!(limit_amount > 0, "invalid-limit-amount");
+            assert!(swap.len() > 0, "invalid-swap");
+            self.assert_asset_approved(*swap[0].token_amount.token);
+            // TODO How to/Should we check the token out is approved?
+            // self.assert_asset_approved(*swap[swap.len() - 1].token_amount.token);
             // TODO Protect with an oracle enforced min slippage
             call_core_with_callback(self.ekubo_core.read(), @SwapParams { swap, limit_amount })
         }
@@ -341,6 +366,9 @@ pub mod ManagedVault {
             debt: Amount,
         ) -> UpdatePositionResponse {
             self.assert_manager();
+            self.assert_asset_approved(collateral_asset);
+            self.assert_asset_approved(debt_asset);
+
             let singleton = self.singleton.read();
 
             let (position_before, _, _) = singleton
@@ -353,8 +381,8 @@ pub mod ManagedVault {
                         collateral_asset,
                         debt_asset,
                         user: get_contract_address(),
-                        collateral: collateral,
-                        debt: debt,
+                        collateral,
+                        debt,
                         data: array![].span(),
                     },
                 );
@@ -395,6 +423,9 @@ pub mod ManagedVault {
                     params.lever_swap_limit_amount,
                 ),
             };
+
+            self.assert_asset_approved(collateral_asset);
+            self.assert_asset_approved(debt_asset);
 
             assert!(lever_swap_limit_amount > 0, "invalid-lever-swap-limit-amount");
 
@@ -444,7 +475,8 @@ pub mod ManagedVault {
                 self.asset.read().balance_of(get_contract_address())
             };
 
-            let (extension, pool_id) = self.price_source.read();
+            let (extension, pool_id) = self.price_source();
+            // TODO Use pragma instead?
             let price = IExtensionDispatcher { contract_address: extension }
                 .price(pool_id, self.asset.read().contract_address);
             assets += balance * price.value / self.scale.read();

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -343,6 +343,7 @@ pub mod ManagedVault {
             self.assert_manager();
             // TODO What if the interface changes?
             // TODO Shouldn't this do more? Like swap + modify position?
+            // TODO Check, should the reward contract be approved by the manager?
             IMerkleDistributorDispatcher { contract_address: rewards_contract }
                 .claim(claim.amount, proof);
         }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -215,7 +215,6 @@ pub mod ManagedVault {
         multiply: ContractAddress,
         redemption_timeout: u64,
         oracle_address: ContractAddress,
-        summary_address: ContractAddress,
     ) {
         self.erc20.initializer(name, symbol, decimals);
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -234,6 +234,7 @@ pub mod ManagedVault {
             assert!(price_buy.value != 0, "price-out-zero");
             // TODO Assert price fairness
         // assert(price out > (sell_amount * price * slippage) / (buy_price * scale))
+        // Rounding has to be Ceil in this case
 
         }
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -234,15 +234,16 @@ pub mod ManagedVault {
         fn assert_fair_rate(
             self: @ContractState,
             sell_token: ContractAddress,
+            sell_token_pool_id: felt252,
             sell_amount: u256,
             buy_token: ContractAddress,
+            buy_token_pool_id: felt252,
             buy_amount: u256,
         ) {
-            // TODO Update get config and get price from pragma
-            let (extension, pool_id) = self.price_source();
+            let (extension, _) = self.price_source();
             let extension = IExtensionDispatcher { contract_address: extension };
-            let price_sell = extension.price(pool_id, sell_token);
-            let price_buy = extension.price(pool_id, buy_token);
+            let price_sell = extension.price(sell_token_pool_id, sell_token);
+            let price_buy = extension.price(buy_token_pool_id, buy_token);
             assert!(price_sell.is_valid, "price-sell-invalid");
             assert!(price_buy.is_valid, "price-buy-invalid");
             assert!(price_sell.value != 0, "price-sell-zero");
@@ -418,6 +419,8 @@ pub mod ManagedVault {
 
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
+            let this = get_contract_address();
+
             assert!(limit_amount > 0, "invalid-limit-amount");
             let start_token = *swap[0].route[0].pool_key.token0;
             let last_swap = swap[swap.len() - 1];
@@ -427,35 +430,78 @@ pub mod ManagedVault {
             let start_token_dispatcher = IERC20Dispatcher { contract_address: start_token };
             let end_token_dispatcher = IERC20Dispatcher { contract_address: end_token };
             // TODO Should there be a config to tell if asset is legacy or not?
-            let balance_start_before = start_token_dispatcher.balance_of(get_contract_address());
-            let balance_end_before = end_token_dispatcher.balance_of(get_contract_address());
+            let AssetConfig {
+                is_legacy: is_legacy_start_token, pool_id: start_token_pool_id,
+            } = self.get_asset_configuration(start_token).unwrap();
+            let balance_start_before = if is_legacy_start_token {
+                start_token_dispatcher.balanceOf(this)
+            } else {
+                start_token_dispatcher.balance_of(this)
+            };
+            let AssetConfig {
+                is_legacy: is_legacy_end_token, pool_id: end_token_pool_id,
+            } = self.get_asset_configuration(end_token).unwrap();
+            let balance_end_before = if is_legacy_end_token {
+                end_token_dispatcher.balanceOf(this)
+            } else {
+                end_token_dispatcher.balance_of(this)
+            };
             // Do the swap
             let _: () = call_core_with_callback(
                 self.ekubo_core.read(), @SwapParams { swap, limit_amount },
             );
-            let balance_start_after = start_token_dispatcher.balance_of(get_contract_address());
-            let balance_end_after = end_token_dispatcher.balance_of(get_contract_address());
+
+            let balance_start_after = if is_legacy_start_token {
+                start_token_dispatcher.balanceOf(this)
+            } else {
+                start_token_dispatcher.balance_of(this)
+            };
+            let balance_end_after = if is_legacy_end_token {
+                end_token_dispatcher.balanceOf(this)
+            } else {
+                end_token_dispatcher.balance_of(this)
+            };
             // Decide which token is in/out based on the balance change
             let is_selling_start_token = balance_start_after < balance_start_before;
-            let (sell_amount, buy_amount, sell_token, buy_token) = if is_selling_start_token {
+            let (
+                sell_token,
+                sell_token_pool_id,
+                sell_amount,
+                buy_token,
+                buy_token_pool_id,
+                buy_amount,
+            ) =
+                if is_selling_start_token {
                 assert!(balance_end_after > balance_end_before, "swap-balance-mismatch");
                 (
-                    balance_start_before - balance_start_after,
-                    balance_end_after - balance_end_before,
                     start_token,
+                    start_token_pool_id,
+                    balance_start_before - balance_start_after,
                     end_token,
+                    end_token_pool_id,
+                    balance_end_after - balance_end_before,
                 )
             } else {
                 assert!(balance_end_before > balance_end_after, "swap-balance-mismatch");
                 (
-                    balance_end_before - balance_end_after,
-                    balance_start_after - balance_start_before,
                     end_token,
+                    end_token_pool_id,
+                    balance_end_before - balance_end_after,
                     start_token,
+                    start_token_pool_id,
+                    balance_start_after - balance_start_before,
                 )
             };
 
-            self.assert_fair_rate(sell_token, sell_amount, buy_token, buy_amount);
+            self
+                .assert_fair_rate(
+                    sell_token,
+                    sell_token_pool_id,
+                    sell_amount,
+                    buy_token,
+                    buy_token_pool_id,
+                    buy_amount,
+                );
         }
 
         fn modify_position(

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -395,21 +395,15 @@ pub mod ManagedVault {
             self.price_source.read()
         }
 
-
         fn modify_asset_configuration(
             ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
-            // Enabling this assertion would prevent to remove an asset configuration
-            // assert_asset_config(asset_configuration);
+            assert_asset_config(asset_configuration);
 
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, _) = self.asset_config[asset_index].read();
-                if asset == read_asset {
-                    // TODO Should we allow to update an existing asset configuration?
-                    self.asset_config[asset_index].write((read_asset, asset_configuration));
-                    return;
-                }
+                assert!(read_asset != asset, "asset-already-configured");
             }
             // If the asset configuration does not exist, add it
             self.asset_config.push((asset, asset_configuration));

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -45,7 +45,7 @@ pub trait IManagedVault<TContractState> {
     fn modify_delegation(
         ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
     );
-    fn add_asset_configuration(
+    fn modify_asset_configuration(
         ref self: TContractState, asset: ContractAddress, asset_configuration: AssetConfig,
     );
     fn get_asset_configuration(
@@ -250,19 +250,6 @@ pub mod ManagedVault {
             assert!(self.get_asset_configuration(asset).is_some(), "asset-not-approved");
         }
 
-        fn get_approved_assets(self: @ContractState) -> Array<(ContractAddress, AssetConfig)> {
-            let mut approved_assets = array![];
-            for asset_index in 0..self.asset_config.len() {
-                let (read_asset, config) = self.asset_config[asset_index].read();
-                // Skip if the asset configuration was removed
-                if config == Default::default() {
-                    continue;
-                }
-                approved_assets.append((read_asset, config));
-            }
-            approved_assets
-        }
-
         #[inline(always)]
         fn balance_of_self(self: @ContractState, asset: ContractAddress, is_legacy: bool) -> u256 {
             if is_legacy {
@@ -395,17 +382,24 @@ pub mod ManagedVault {
             self.price_source.read()
         }
 
-        fn add_asset_configuration(
+        fn modify_asset_configuration(
             ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
-            assert_asset_config(asset_configuration);
 
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, _) = self.asset_config[asset_index].read();
-                assert!(read_asset != asset, "asset-already-configured");
+                if asset == read_asset {
+                    if asset_configuration != Default::default() {
+                        // If the asset configuration is not empty check it is valid
+                        assert_asset_config(asset_configuration);
+                    }
+                    self.asset_config[asset_index].write((read_asset, asset_configuration));
+                    return;
+                }
             }
             // If the asset configuration does not exist, add it
+            assert_asset_config(asset_configuration);
             self.asset_config.push((asset, asset_configuration));
         }
 
@@ -424,6 +418,20 @@ pub mod ManagedVault {
             }
             None
         }
+
+        fn get_approved_assets(self: @ContractState) -> Array<(ContractAddress, AssetConfig)> {
+            let mut approved_assets = array![];
+            for asset_index in 0..self.asset_config.len() {
+                let (read_asset, config) = self.asset_config[asset_index].read();
+                // Skip if the asset configuration was removed
+                if config == Default::default() {
+                    continue;
+                }
+                approved_assets.append((read_asset, config));
+            }
+            approved_assets
+        }
+
 
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {
             self.assert_owner();
@@ -510,7 +518,7 @@ pub mod ManagedVault {
             }
 
             assert_asset_config(oracle_config);
-            self.add_asset_configuration(asset, oracle_config);
+            self.modify_asset_configuration(asset, oracle_config);
             // self.emit(SetOracleParameter { asset, parameter, value });
         }
         /////////////////////////

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -100,7 +100,7 @@ pub mod ManagedVault {
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use vesu::common::calculate_collateral_and_debt_value;
-    use vesu::data_model::{Amount, AssetPrice, ModifyPositionParams, UpdatePositionResponse};
+    use vesu::data_model::{Amount, ModifyPositionParams, UpdatePositionResponse};
     use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
     use vesu::math::pow_10;
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
@@ -223,19 +223,33 @@ pub mod ManagedVault {
 
         fn assert_fair_rate(
             self: @ContractState,
+            sell_token: ContractAddress,
             sell_amount: u256,
-            bought_amount: u256,
-            price_sell: AssetPrice,
-            price_buy: AssetPrice,
+            buy_token: ContractAddress,
+            buy_amount: u256,
         ) {
+            let (extension, pool_id) = self.price_source();
+            let extension = IExtensionDispatcher { contract_address: extension };
+            let price_sell = extension.price(pool_id, sell_token);
+            let price_buy = extension.price(pool_id, buy_token);
             assert!(price_sell.is_valid, "price-sell-invalid");
             assert!(price_buy.is_valid, "price-buy-invalid");
             assert!(price_sell.value != 0, "price-sell-zero");
             assert!(price_buy.value != 0, "price-out-zero");
-            // TODO Assert price fairness
-        // assert(price out > (sell_amount * price * slippage) / (buy_price * scale))
-        // Rounding has to be Ceil in this case
-
+            // TODO Protect this with.a read-only lock? Since owner has to approve the asset, is it
+            // even useful?
+            let sell_token_decimals = IERC20Dispatcher { contract_address: sell_token }.decimals();
+            let buy_token_decimals = IERC20Dispatcher { contract_address: buy_token }.decimals();
+            // TODO slippage
+            // TODO handle rounding: has to be Ceil in this case
+            let min_bought_amount = if sell_token_decimals > buy_token_decimals {
+                let scale_div = pow_10(sell_token_decimals.into() - buy_token_decimals.into());
+                (sell_amount * price_sell.value) / (price_buy.value * scale_div)
+            } else {
+                let scale_mul = pow_10(buy_token_decimals.into() - sell_token_decimals.into());
+                (sell_amount * price_sell.value * scale_mul) / (price_buy.value)
+            };
+            assert!(buy_amount >= min_bought_amount, "price-out-too-low");
         }
 
         fn transfer_asset(
@@ -374,38 +388,35 @@ pub mod ManagedVault {
             self.assert_asset_approved(end_token);
             let start_token_dispatcher = IERC20Dispatcher { contract_address: start_token };
             let end_token_dispatcher = IERC20Dispatcher { contract_address: end_token };
-            let balance_in_before = start_token_dispatcher.balanceOf(get_contract_address());
-            let balance_out_before = end_token_dispatcher.balanceOf(get_contract_address());
+            let balance_start_before = start_token_dispatcher.balanceOf(get_contract_address());
+            let balance_end_before = end_token_dispatcher.balanceOf(get_contract_address());
             // Do the swap
-            let x = call_core_with_callback(
+            let _: () = call_core_with_callback(
                 self.ekubo_core.read(), @SwapParams { swap, limit_amount },
             );
-            // TODO Protect with an oracle enforced min slippage
-            let balance_in_after = start_token_dispatcher.balanceOf(get_contract_address());
-            let balance_out_after = end_token_dispatcher.balanceOf(get_contract_address());
+            let balance_start_after = start_token_dispatcher.balanceOf(get_contract_address());
+            let balance_end_after = end_token_dispatcher.balanceOf(get_contract_address());
             // Decide which token is in/out based on the balance change
-            let (extension, pool_id) = self.price_source();
-            let extension = IExtensionDispatcher { contract_address: extension };
-            let is_negative = balance_in_after < balance_in_before;
-            let (sell_amount, buy_amount, price_sell, price_buy) = if is_negative {
+            let is_selling_start_token = balance_start_after < balance_start_before;
+            let (sell_amount, buy_amount, sell_token, buy_token) = if is_selling_start_token {
+                assert!(balance_end_after > balance_end_before, "swap-balance-mismatch");
                 (
-                    balance_in_before - balance_in_after,
-                    balance_out_after - balance_out_before,
-                    extension.price(pool_id, start_token),
-                    extension.price(pool_id, end_token),
+                    balance_start_before - balance_start_after,
+                    balance_end_after - balance_end_before,
+                    start_token,
+                    end_token,
                 )
             } else {
+                assert!(balance_end_before > balance_end_after, "swap-balance-mismatch");
                 (
-                    balance_out_before - balance_out_after,
-                    balance_in_after - balance_in_before,
-                    extension.price(pool_id, end_token),
-                    extension.price(pool_id, start_token),
+                    balance_end_before - balance_end_after,
+                    balance_start_after - balance_start_before,
+                    end_token,
+                    start_token,
                 )
             };
 
-            self.assert_fair_rate(sell_amount, buy_amount, price_sell, price_buy);
-
-            x
+            self.assert_fair_rate(sell_token, sell_amount, buy_token, buy_amount);
         }
 
         fn modify_position(

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -238,8 +238,6 @@ pub mod ManagedVault {
         fn _swap(ref self: ContractState, params: SwapParams) {
             let core = self.ekubo_core.read();
             let (input_amount, output_amount) = swap(core, params.swap, params.limit_amount);
-            self.assert_asset_approved(input_amount.token);
-            self.assert_asset_approved(output_amount.token);
             handle_delta(core, output_amount.token, output_amount.amount, get_contract_address());
             handle_delta(core, input_amount.token, input_amount.amount, get_contract_address());
         }
@@ -352,9 +350,11 @@ pub mod ManagedVault {
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
             assert!(limit_amount > 0, "invalid-limit-amount");
-            assert!(swap.len() > 0, "invalid-swap");
             for local_swap in swap.span() {
-                self.assert_asset_approved(*local_swap.token_amount.token);
+                for route_node in local_swap.route.span() {
+                    self.assert_asset_approved(*route_node.pool_key.token0);
+                    self.assert_asset_approved(*route_node.pool_key.token1);
+                }
             }
             // TODO Protect with an oracle enforced min slippage
             call_core_with_callback(self.ekubo_core.read(), @SwapParams { swap, limit_amount })

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -45,7 +45,7 @@ pub trait IManagedVault<TContractState> {
     fn modify_delegation(
         ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
     );
-    fn modify_asset_configuration(
+    fn add_asset_configuration(
         ref self: TContractState, asset: ContractAddress, asset_configuration: AssetConfig,
     );
     fn get_asset_configuration(
@@ -395,7 +395,7 @@ pub mod ManagedVault {
             self.price_source.read()
         }
 
-        fn modify_asset_configuration(
+        fn add_asset_configuration(
             ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
@@ -510,7 +510,7 @@ pub mod ManagedVault {
             }
 
             assert_asset_config(oracle_config);
-            self.modify_asset_configuration(asset, oracle_config);
+            self.add_asset_configuration(asset, oracle_config);
             // self.emit(SetOracleParameter { asset, parameter, value });
         }
         /////////////////////////

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -274,6 +274,7 @@ pub mod ManagedVault {
             // TODO Configurable slippage
             let slippage_decimals = 4;
             let slippage_bps = 95_00; // 95% of the price
+            // TODO Could use scale from the asset config instead of calling decimals
             let sell_token_decimals = IERC20Dispatcher { contract_address: sell_token }.decimals();
             let buy_token_decimals = IERC20Dispatcher { contract_address: buy_token }
                 .decimals()
@@ -470,6 +471,7 @@ pub mod ManagedVault {
 
             AssetPrice { value, is_valid }
         }
+
         fn set_asset_configuration_parameter(
             ref self: ContractState, asset: ContractAddress, parameter: felt252, value: felt252,
         ) {
@@ -529,7 +531,7 @@ pub mod ManagedVault {
             let end_token = *last_swap.route[last_swap.route.len() - 1].pool_key.token1;
             self.assert_asset_approved(start_token);
             self.assert_asset_approved(end_token);
-            // TODO Should there be a config to tell if asset is legacy or not?
+
             let AssetConfig {
                 is_legacy: is_legacy_start_token, ..,
             } = self.get_asset_configuration(start_token).unwrap();
@@ -689,10 +691,6 @@ pub mod ManagedVault {
             assets += balance * price.value / self.scale.read();
 
             // Loop through all approved assets and add their value
-            // What if the asset is not in the pool?
-            // What if the asset feed isn't in usdc
-            // Should it keep track
-
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, config) = self.asset_config[asset_index].read();
                 // Skip if the asset configuration was removed

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -66,7 +66,7 @@ pub trait IManagedVault<TContractState> {
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
     fn modify_asset_configuration(
-        ref self: TContractState, asset: ContractAddress, asset_configuration: Option<AssetConfig>,
+        ref self: TContractState, asset: ContractAddress, asset_configuration: AssetConfig,
     );
     fn get_asset_configuration(
         self: @TContractState, asset: ContractAddress,
@@ -90,11 +90,10 @@ pub struct SwapParams {
     pub swap: Array<Swap>,
     pub limit_amount: u128,
 }
-
-#[derive(Serde, PartialEq, Drop, Default, Clone, Copy, starknet::Store)]
+#[derive(Serde, PartialEq, Drop, Clone, Default, Copy, starknet::Store)]
 pub struct AssetConfig {
-    pub pragma_id: felt252,
     pub is_legacy: bool,
+    pub pool_id: felt252,
 }
 
 
@@ -361,29 +360,18 @@ pub mod ManagedVault {
 
 
         fn modify_asset_configuration(
-            ref self: ContractState,
-            asset: ContractAddress,
-            asset_configuration: Option<AssetConfig>,
+            ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, _) = self.asset_config[asset_index].read();
                 if asset == read_asset {
-                    // Update existing asset configuration
-                    if let Some(configuration) = asset_configuration {
-                        assert!(configuration != Default::default(), "invalid-asset-configuration");
-                        self.asset_config[asset_index].write((read_asset, configuration));
-                    } else {
-                        // If the asset configuration is None, remove it
-                        self.asset_config[asset_index].write((read_asset, Default::default()));
-                    }
+                    self.asset_config[asset_index].write((read_asset, asset_configuration));
                     return;
                 }
             }
             // If the asset configuration does not exist, add it
-            self
-                .asset_config
-                .push((asset, asset_configuration.expect('Missing asset configuration')));
+            self.asset_config.push((asset, asset_configuration));
         }
 
         fn get_asset_configuration(
@@ -565,6 +553,7 @@ pub mod ManagedVault {
 
         fn nav(self: @ContractState) -> u256 {
             let singleton = self.singleton.read();
+            let this = get_contract_address();
 
             let mut assets = 0;
             let mut liabilities = 0;
@@ -572,8 +561,7 @@ pub mod ManagedVault {
 
             while (position != Zero::zero()) {
                 let Position { pool_id, collateral_asset, debt_asset } = position;
-                let context = singleton
-                    .context(pool_id, collateral_asset, debt_asset, get_contract_address());
+                let context = singleton.context(pool_id, collateral_asset, debt_asset, this);
                 let (_, collateral_value, _, debt_value) = calculate_collateral_and_debt_value(
                     context, context.position,
                 );
@@ -583,26 +571,44 @@ pub mod ManagedVault {
             }
 
             let balance = if self.is_legacy.read() {
-                self.asset.read().balanceOf(get_contract_address())
+                self.asset.read().balanceOf(this)
             } else {
-                self.asset.read().balance_of(get_contract_address())
+                self.asset.read().balance_of(this)
             };
 
             let (extension, pool_id) = self.price_source();
-            let price = IExtensionDispatcher { contract_address: extension }
-                .price(pool_id, self.asset.read().contract_address);
+            let extension = IExtensionDispatcher { contract_address: extension };
+            let price = extension.price(pool_id, self.asset.read().contract_address);
             assets += balance * price.value / self.scale.read();
 
             // Loop through all approved assets and add their value
+            // What if the asset is not in the pool?
+            // What if the asset feed isn't in usdc
+            // Should it keep track
+
             for asset_index in 0..self.asset_config.len() {
                 let (asset, config) = self.asset_config[asset_index].read();
-                let balance = if config.is_legacy {
-                    IERC20Dispatcher { contract_address: asset }.balanceOf(get_contract_address())
+                // Skip if the asset configuration was removed
+                if config == Default::default() {
+                    continue;
+                }
+
+                // Skip if the asset is the vault's underlying asset
+                // This is important to avoid double counting the asset
+                if asset == self.asset.read().contract_address {
+                    continue;
+                }
+                let AssetConfig { is_legacy, pool_id } = config;
+                let balance = if is_legacy {
+                    IERC20Dispatcher { contract_address: asset }.balanceOf(this)
                 } else {
-                    IERC20Dispatcher { contract_address: asset }.balance_of(get_contract_address())
+                    IERC20Dispatcher { contract_address: asset }.balance_of(this)
                 };
-                // TODO Get price from pragma and remove scale
-                assets += balance;
+
+                let (collateral_asset_config, _) = singleton.asset_config(pool_id, asset);
+                let asset_price = extension.price(pool_id, asset);
+
+                assets += balance * asset_price.value / collateral_asset_config.scale;
             }
 
             assets - liabilities

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -620,7 +620,7 @@ pub mod ManagedVault {
             // Should it keep track
 
             for asset_index in 0..self.asset_config.len() {
-                let (local_asset, config) = self.asset_config[asset_index].read();
+                let (read_asset, config) = self.asset_config[asset_index].read();
                 // Skip if the asset configuration was removed
                 if config == Default::default() {
                     continue;
@@ -628,14 +628,14 @@ pub mod ManagedVault {
 
                 // Skip if the asset is the vault's underlying asset
                 // This is important to avoid double counting the asset
-                if local_asset == asset.contract_address {
+                if read_asset == asset.contract_address {
                     continue;
                 }
                 let AssetConfig { is_legacy, pool_id } = config;
-                let balance = self.balance_of_self(local_asset, is_legacy);
+                let balance = self.balance_of_self(read_asset, is_legacy);
 
-                let (collateral_asset_config, _) = singleton.asset_config(pool_id, local_asset);
-                let asset_price = extension.price(pool_id, local_asset);
+                let (collateral_asset_config, _) = singleton.asset_config(pool_id, read_asset);
+                let asset_price = extension.price(pool_id, read_asset);
 
                 assets += balance * asset_price.value / collateral_asset_config.scale;
             }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -51,6 +51,7 @@ pub trait IManagedVault<TContractState> {
     fn get_asset_configuration(
         self: @TContractState, asset: ContractAddress,
     ) -> Option<AssetConfig>;
+    fn get_approved_assets(self: @TContractState) -> Array<(ContractAddress, AssetConfig)>;
     fn pragma_oracle(self: @TContractState) -> ContractAddress;
     fn set_oracle(ref self: TContractState, oracle_address: ContractAddress);
     fn price(self: @TContractState, asset: ContractAddress) -> AssetPrice;
@@ -247,6 +248,19 @@ pub mod ManagedVault {
 
         fn assert_asset_approved(self: @ContractState, asset: ContractAddress) {
             assert!(self.get_asset_configuration(asset).is_some(), "asset-not-approved");
+        }
+
+        fn get_approved_assets(self: @ContractState) -> Array<(ContractAddress, AssetConfig)> {
+            let mut approved_assets = array![];
+            for asset_index in 0..self.asset_config.len() {
+                let (read_asset, config) = self.asset_config[asset_index].read();
+                // Skip if the asset configuration was removed
+                if config == Default::default() {
+                    continue;
+                }
+                approved_assets.append((read_asset, config));
+            }
+            approved_assets
         }
 
         #[inline(always)]

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -65,8 +65,10 @@ pub trait IManagedVault<TContractState> {
         ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
-    fn modify_asset(ref self: TContractState, asset: ContractAddress, is_approved: bool);
-    fn is_asset_approved(self: @TContractState, asset: ContractAddress) -> bool;
+    fn modify_asset_configuration(ref self: TContractState, asset_configuration: AssetConfig);
+    fn get_asset_configuration(
+        self: @TContractState, asset: ContractAddress,
+    ) -> Option<AssetConfig>;
 
     // User related functions
     fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
@@ -87,6 +89,14 @@ pub struct SwapParams {
     pub limit_amount: u128,
 }
 
+#[derive(Serde, Drop, Clone, Copy, starknet::Store)]
+pub struct AssetConfig {
+    pub asset: ContractAddress,
+    pub pragma_id: felt252,
+    pub is_legacy: bool,
+}
+
+
 #[starknet::contract]
 pub mod ManagedVault {
     use core::num::traits::{Bounded, Zero};
@@ -95,8 +105,8 @@ pub mod ManagedVault {
     };
     use ekubo::interfaces::core::{ICoreDispatcher, ILocker};
     use starknet::storage::{
-        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
-        StoragePointerWriteAccess,
+        Map, MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess, Vec, VecTrait,
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use vesu::common::calculate_collateral_and_debt_value;
@@ -108,8 +118,8 @@ pub mod ManagedVault {
     use vesu::vendor::erc20::{ERC20ABIDispatcher as IERC20Dispatcher, ERC20ABIDispatcherTrait};
     use vesu::vendor::erc20_component::ERC20Component;
     use vesu_periphery::managed_vault::{
-        Claim, IManagedVault, IMerkleDistributorDispatcher, IMerkleDistributorDispatcherTrait,
-        SwapParams,
+        AssetConfig, Claim, IManagedVault, IMerkleDistributorDispatcher,
+        IMerkleDistributorDispatcherTrait, SwapParams,
     };
     use vesu_periphery::multiply::{
         IMultiplyDispatcher, IMultiplyDispatcherTrait, ModifyLeverAction, ModifyLeverParams,
@@ -159,6 +169,7 @@ pub mod ManagedVault {
         // Map of approved assets from the owner
         // (asset, is_approved)
         approved_asset: Map<ContractAddress, bool>,
+        asset_config: Vec<AssetConfig>,
         // storage for the timestamp manager component
         #[substorage(v0)]
         position_list: position_list_component::Storage,
@@ -218,7 +229,7 @@ pub mod ManagedVault {
         }
 
         fn assert_asset_approved(self: @ContractState, asset: ContractAddress) {
-            assert!(self.is_asset_approved(asset), "asset-not-approved");
+            assert!(self.get_asset_configuration(asset).is_some(), "asset-not-approved");
         }
 
         fn assert_fair_rate(
@@ -228,6 +239,7 @@ pub mod ManagedVault {
             buy_token: ContractAddress,
             buy_amount: u256,
         ) {
+            // TODO Update get config and get price from pragma
             let (extension, pool_id) = self.price_source();
             let extension = IExtensionDispatcher { contract_address: extension };
             let price_sell = extension.price(pool_id, sell_token);
@@ -348,13 +360,30 @@ pub mod ManagedVault {
         }
 
 
-        fn modify_asset(ref self: ContractState, asset: ContractAddress, is_approved: bool) {
+        fn modify_asset_configuration(ref self: ContractState, asset_configuration: AssetConfig) {
             self.assert_owner();
-            self.approved_asset.write(asset, is_approved);
+            for asset_index in 0..self.asset_config.len() {
+                let asset_config = self.asset_config[asset_index].read();
+                if asset_config.asset == asset_configuration.asset {
+                    // Update existing asset configuration
+                    self.asset_config[asset_index].write(asset_configuration);
+                    return;
+                }
+            }
+            // If the asset configuration does not exist, add it
+            self.asset_config.push(asset_configuration);
         }
 
-        fn is_asset_approved(self: @ContractState, asset: ContractAddress) -> bool {
-            self.approved_asset.read(asset)
+        fn get_asset_configuration(
+            self: @ContractState, asset: ContractAddress,
+        ) -> Option<AssetConfig> {
+            for asset_index in 0..self.asset_config.len() {
+                let asset_config = self.asset_config[asset_index].read();
+                if asset_config.asset == asset {
+                    return Some(asset_config);
+                }
+            }
+            None
         }
 
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {
@@ -547,6 +576,20 @@ pub mod ManagedVault {
             let price = IExtensionDispatcher { contract_address: extension }
                 .price(pool_id, self.asset.read().contract_address);
             assets += balance * price.value / self.scale.read();
+
+            // Loop through all approved assets and add their value
+            for asset_index in 0..self.asset_config.len() {
+                let asset_config = self.asset_config[asset_index].read();
+                let balance = if asset_config.is_legacy {
+                    IERC20Dispatcher { contract_address: asset_config.asset }
+                        .balanceOf(get_contract_address())
+                } else {
+                    IERC20Dispatcher { contract_address: asset_config.asset }
+                        .balance_of(get_contract_address())
+                };
+                // TODO Get price from pragma and remove scale
+                assets += balance;
+            }
 
             assets - liabilities
         }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -156,6 +156,8 @@ pub mod ManagedVault {
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
+        // Map of approved assets from the owner
+        // (asset, is_approved)
         approved_asset: Map<ContractAddress, bool>,
         // storage for the timestamp manager component
         #[substorage(v0)]

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -236,7 +236,7 @@ pub mod ManagedVault {
             assert!(price_buy.is_valid, "price-buy-invalid");
             assert!(price_sell.value != 0, "price-sell-zero");
             assert!(price_buy.value != 0, "price-out-zero");
-            // TODO Protect this with.a read-only lock? Since owner has to approve the asset, is it
+            // TODO Protect this with a read-only lock? Since owner has to approve the asset, is it
             // even useful?
             let sell_token_decimals = IERC20Dispatcher { contract_address: sell_token }.decimals();
             let buy_token_decimals = IERC20Dispatcher { contract_address: buy_token }.decimals();

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -351,9 +351,9 @@ pub mod ManagedVault {
             self.assert_manager();
             assert!(limit_amount > 0, "invalid-limit-amount");
             assert!(swap.len() > 0, "invalid-swap");
-            self.assert_asset_approved(*swap[0].token_amount.token);
-            // TODO How to/Should we check the token out is approved?
-            // self.assert_asset_approved(*swap[swap.len() - 1].token_amount.token);
+            for local_swap in swap.span() {
+                self.assert_asset_approved(*local_swap.token_amount.token);
+            }
             // TODO Protect with an oracle enforced min slippage
             call_core_with_callback(self.ekubo_core.read(), @SwapParams { swap, limit_amount })
         }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -93,6 +93,7 @@ pub struct SwapParams {
 #[derive(Serde, PartialEq, Drop, Clone, Default, Copy, starknet::Store)]
 pub struct AssetConfig {
     pub is_legacy: bool,
+    // TODO Do we also need the extension?
     pub pool_id: felt252,
 }
 

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -65,7 +65,9 @@ pub trait IManagedVault<TContractState> {
         ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
-    fn modify_asset_configuration(ref self: TContractState, asset_configuration: AssetConfig);
+    fn modify_asset_configuration(
+        ref self: TContractState, asset: ContractAddress, asset_configuration: Option<AssetConfig>,
+    );
     fn get_asset_configuration(
         self: @TContractState, asset: ContractAddress,
     ) -> Option<AssetConfig>;
@@ -89,9 +91,8 @@ pub struct SwapParams {
     pub limit_amount: u128,
 }
 
-#[derive(Serde, Drop, Clone, Copy, starknet::Store)]
+#[derive(Serde, PartialEq, Drop, Default, Clone, Copy, starknet::Store)]
 pub struct AssetConfig {
-    pub asset: ContractAddress,
     pub pragma_id: felt252,
     pub is_legacy: bool,
 }
@@ -167,7 +168,8 @@ pub mod ManagedVault {
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
         // List of all approved assets and their configuration
-        asset_config: Vec<AssetConfig>,
+        // TODO This could be further improved by using a more efficient data structure
+        asset_config: Vec<(ContractAddress, AssetConfig)>,
         // storage for the timestamp manager component
         #[substorage(v0)]
         position_list: position_list_component::Storage,
@@ -358,28 +360,43 @@ pub mod ManagedVault {
         }
 
 
-        fn modify_asset_configuration(ref self: ContractState, asset_configuration: AssetConfig) {
+        fn modify_asset_configuration(
+            ref self: ContractState,
+            asset: ContractAddress,
+            asset_configuration: Option<AssetConfig>,
+        ) {
             self.assert_owner();
-            // TODO Handle asset removal
             for asset_index in 0..self.asset_config.len() {
-                let asset_config = self.asset_config[asset_index].read();
-                if asset_config.asset == asset_configuration.asset {
+                let (read_asset, _) = self.asset_config[asset_index].read();
+                if asset == read_asset {
                     // Update existing asset configuration
-                    self.asset_config[asset_index].write(asset_configuration);
+                    if let Some(configuration) = asset_configuration {
+                        assert!(configuration != Default::default(), "invalid-asset-configuration");
+                        self.asset_config[asset_index].write((read_asset, configuration));
+                    } else {
+                        // If the asset configuration is None, remove it
+                        self.asset_config[asset_index].write((read_asset, Default::default()));
+                    }
                     return;
                 }
             }
             // If the asset configuration does not exist, add it
-            self.asset_config.push(asset_configuration);
+            self
+                .asset_config
+                .push((asset, asset_configuration.expect('Missing asset configuration')));
         }
 
         fn get_asset_configuration(
             self: @ContractState, asset: ContractAddress,
         ) -> Option<AssetConfig> {
             for asset_index in 0..self.asset_config.len() {
-                let asset_config = self.asset_config[asset_index].read();
-                if asset_config.asset == asset {
-                    return Some(asset_config);
+                let (read_asset, config) = self.asset_config[asset_index].read();
+                if read_asset == asset {
+                    // Asset configuration was removed
+                    if config == Default::default() {
+                        return None;
+                    }
+                    return Some(config);
                 }
             }
             None
@@ -578,13 +595,11 @@ pub mod ManagedVault {
 
             // Loop through all approved assets and add their value
             for asset_index in 0..self.asset_config.len() {
-                let asset_config = self.asset_config[asset_index].read();
-                let balance = if asset_config.is_legacy {
-                    IERC20Dispatcher { contract_address: asset_config.asset }
-                        .balanceOf(get_contract_address())
+                let (asset, config) = self.asset_config[asset_index].read();
+                let balance = if config.is_legacy {
+                    IERC20Dispatcher { contract_address: asset }.balanceOf(get_contract_address())
                 } else {
-                    IERC20Dispatcher { contract_address: asset_config.asset }
-                        .balance_of(get_contract_address())
+                    IERC20Dispatcher { contract_address: asset }.balance_of(get_contract_address())
                 };
                 // TODO Get price from pragma and remove scale
                 assets += balance;

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -100,7 +100,7 @@ pub mod ManagedVault {
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use vesu::common::calculate_collateral_and_debt_value;
-    use vesu::data_model::{Amount, ModifyPositionParams, UpdatePositionResponse};
+    use vesu::data_model::{Amount, AssetPrice, ModifyPositionParams, UpdatePositionResponse};
     use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
     use vesu::math::pow_10;
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
@@ -219,6 +219,22 @@ pub mod ManagedVault {
 
         fn assert_asset_approved(self: @ContractState, asset: ContractAddress) {
             assert!(self.is_asset_approved(asset), "asset-not-approved");
+        }
+
+        fn assert_fair_rate(
+            self: @ContractState,
+            sell_amount: u256,
+            bought_amount: u256,
+            price_sell: AssetPrice,
+            price_buy: AssetPrice,
+        ) {
+            assert!(price_sell.is_valid, "price-sell-invalid");
+            assert!(price_buy.is_valid, "price-buy-invalid");
+            assert!(price_sell.value != 0, "price-sell-zero");
+            assert!(price_buy.value != 0, "price-out-zero");
+            // TODO Assert price fairness
+        // assert(price out > (sell_amount * price * slippage) / (buy_price * scale))
+
         }
 
         fn transfer_asset(
@@ -350,14 +366,45 @@ pub mod ManagedVault {
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
             assert!(limit_amount > 0, "invalid-limit-amount");
-            for local_swap in swap.span() {
-                for route_node in local_swap.route.span() {
-                    self.assert_asset_approved(*route_node.pool_key.token0);
-                    self.assert_asset_approved(*route_node.pool_key.token1);
-                }
-            }
+            let start_token = *swap[0].route[0].pool_key.token0;
+            let last_swap = swap[swap.len() - 1];
+            let end_token = *last_swap.route[last_swap.route.len() - 1].pool_key.token1;
+            self.assert_asset_approved(start_token);
+            self.assert_asset_approved(end_token);
+            let start_token_dispatcher = IERC20Dispatcher { contract_address: start_token };
+            let end_token_dispatcher = IERC20Dispatcher { contract_address: end_token };
+            let balance_in_before = start_token_dispatcher.balanceOf(get_contract_address());
+            let balance_out_before = end_token_dispatcher.balanceOf(get_contract_address());
+            // Do the swap
+            let x = call_core_with_callback(
+                self.ekubo_core.read(), @SwapParams { swap, limit_amount },
+            );
             // TODO Protect with an oracle enforced min slippage
-            call_core_with_callback(self.ekubo_core.read(), @SwapParams { swap, limit_amount })
+            let balance_in_after = start_token_dispatcher.balanceOf(get_contract_address());
+            let balance_out_after = end_token_dispatcher.balanceOf(get_contract_address());
+            // Decide which token is in/out based on the balance change
+            let (extension, pool_id) = self.price_source();
+            let extension = IExtensionDispatcher { contract_address: extension };
+            let is_negative = balance_in_after < balance_in_before;
+            let (sell_amount, buy_amount, price_sell, price_buy) = if is_negative {
+                (
+                    balance_in_before - balance_in_after,
+                    balance_out_after - balance_out_before,
+                    extension.price(pool_id, start_token),
+                    extension.price(pool_id, end_token),
+                )
+            } else {
+                (
+                    balance_out_before - balance_out_after,
+                    balance_in_after - balance_in_before,
+                    extension.price(pool_id, end_token),
+                    extension.price(pool_id, start_token),
+                )
+            };
+
+            self.assert_fair_rate(sell_amount, buy_amount, price_sell, price_buy);
+
+            x
         }
 
         fn modify_position(
@@ -479,7 +526,6 @@ pub mod ManagedVault {
             };
 
             let (extension, pool_id) = self.price_source();
-            // TODO Use pragma instead?
             let price = IExtensionDispatcher { contract_address: extension }
                 .price(pool_id, self.asset.read().contract_address);
             assets += balance * price.value / self.scale.read();

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -342,6 +342,7 @@ pub mod ManagedVault {
         ) {
             self.assert_manager();
             // TODO What if the interface changes?
+            // TODO Shouldn't this do more? Like swap + modify position?
             IMerkleDistributorDispatcher { contract_address: rewards_contract }
                 .claim(claim.amount, proof);
         }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -1,5 +1,6 @@
 use starknet::ContractAddress;
-use vesu::data_model::{Amount, UpdatePositionResponse};
+use vesu::data_model::{Amount, AssetPrice, UpdatePositionResponse};
+use vesu::vendor::pragma::AggregationMode;
 use vesu_periphery::multiply::{ModifyLeverParams, ModifyLeverResponse};
 use vesu_periphery::swap::Swap;
 
@@ -44,6 +45,18 @@ pub trait IManagedVault<TContractState> {
     fn modify_delegation(
         ref self: TContractState, pool_id: felt252, delegatee: ContractAddress, delegation: bool,
     );
+    fn modify_asset_configuration(
+        ref self: TContractState, asset: ContractAddress, asset_configuration: AssetConfig,
+    );
+    fn get_asset_configuration(
+        self: @TContractState, asset: ContractAddress,
+    ) -> Option<AssetConfig>;
+    fn pragma_oracle(self: @TContractState) -> ContractAddress;
+    fn set_oracle(ref self: TContractState, oracle_address: ContractAddress);
+    fn price(self: @TContractState, asset: ContractAddress) -> AssetPrice;
+    fn set_asset_configuration_parameter(
+        ref self: TContractState, asset: ContractAddress, parameter: felt252, value: felt252,
+    );
 
     // Management functions
     fn claim_rewards(
@@ -65,12 +78,6 @@ pub trait IManagedVault<TContractState> {
         ref self: TContractState, modify_lever_params: ModifyLeverParams,
     ) -> ModifyLeverResponse;
     fn nav(self: @TContractState) -> u256;
-    fn modify_asset_configuration(
-        ref self: TContractState, asset: ContractAddress, asset_configuration: AssetConfig,
-    );
-    fn get_asset_configuration(
-        self: @TContractState, asset: ContractAddress,
-    ) -> Option<AssetConfig>;
 
     // User related functions
     fn deposit(ref self: TContractState, assets: u256, receiver: ContractAddress) -> u256;
@@ -93,11 +100,14 @@ pub struct SwapParams {
 #[derive(Serde, PartialEq, Drop, Clone, Default, Copy, starknet::Store)]
 pub struct AssetConfig {
     pub is_legacy: bool,
-    // TODO Do we also need the extension?
-    // TODO Store scale?
-    pub pool_id: felt252,
+    pub scale: u256,
+    pub pragma_key: felt252,
+    pub timeout: u64, // [seconds]
+    pub number_of_sources: u32, // [0, 255]
+    pub start_time_offset: u64, // [seconds]
+    pub time_window: u64, // [seconds]
+    pub aggregation_mode: AggregationMode,
 }
-
 
 #[starknet::contract]
 pub mod ManagedVault {
@@ -112,13 +122,14 @@ pub mod ManagedVault {
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use vesu::common::calculate_collateral_and_debt_value;
-    use vesu::data_model::{Amount, ModifyPositionParams, UpdatePositionResponse};
+    use vesu::data_model::{Amount, AssetPrice, ModifyPositionParams, UpdatePositionResponse};
     use vesu::extension::interface::{IExtensionDispatcher, IExtensionDispatcherTrait};
     use vesu::math::pow_10;
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
     use vesu::units::SCALE;
     use vesu::vendor::erc20::{ERC20ABIDispatcher as IERC20Dispatcher, ERC20ABIDispatcherTrait};
     use vesu::vendor::erc20_component::ERC20Component;
+    use vesu::vendor::pragma::{DataType, IPragmaABIDispatcher, IPragmaABIDispatcherTrait};
     use vesu_periphery::managed_vault::{
         AssetConfig, Claim, IManagedVault, IMerkleDistributorDispatcher,
         IMerkleDistributorDispatcherTrait, SwapParams,
@@ -168,6 +179,8 @@ pub mod ManagedVault {
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
+        // Oracle related storage
+        pragma_oracle_address: ContractAddress,
         // List of all approved assets and their configuration
         // TODO This could be further improved by using a more efficient data structure
         asset_config: Vec<(ContractAddress, AssetConfig)>,
@@ -201,6 +214,8 @@ pub mod ManagedVault {
         ekubo_core: ContractAddress,
         multiply: ContractAddress,
         redemption_timeout: u64,
+        oracle_address: ContractAddress,
+        summary_address: ContractAddress,
     ) {
         self.erc20.initializer(name, symbol, decimals);
 
@@ -217,6 +232,8 @@ pub mod ManagedVault {
         self.multiply.write(IMultiplyDispatcher { contract_address: multiply });
 
         self.redemption_timeout.write(redemption_timeout);
+
+        self.pragma_oracle_address.write(oracle_address);
     }
 
     #[generate_trait]
@@ -245,20 +262,14 @@ pub mod ManagedVault {
         fn assert_fair_rate(
             self: @ContractState,
             sell_token: ContractAddress,
-            sell_token_pool_id: felt252,
             sell_amount: u256,
             buy_token: ContractAddress,
-            buy_token_pool_id: felt252,
             buy_amount: u256,
         ) {
-            let (extension, _) = self.price_source();
-            let extension = IExtensionDispatcher { contract_address: extension };
-            let price_sell = extension.price(sell_token_pool_id, sell_token);
-            let price_buy = extension.price(buy_token_pool_id, buy_token);
-            assert!(price_sell.is_valid, "price-sell-invalid");
-            assert!(price_buy.is_valid, "price-buy-invalid");
-            assert!(price_sell.value != 0, "price-sell-zero");
-            assert!(price_buy.value != 0, "price-buy-zero");
+            let price_sell = self.price(sell_token);
+            let price_buy = self.price(buy_token);
+            assert_price(price_sell);
+            assert_price(price_buy);
             // TODO Protect this with a read-only lock?
             // Since owner has to approve the asset, is it even useful?
             // TODO Configurable slippage
@@ -375,9 +386,12 @@ pub mod ManagedVault {
             ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
+            assert_asset_config(asset_configuration);
+
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, _) = self.asset_config[asset_index].read();
                 if asset == read_asset {
+                    // TODO Should we allow to update an existing asset configuration?
                     self.asset_config[asset_index].write((read_asset, asset_configuration));
                     return;
                 }
@@ -414,6 +428,85 @@ pub mod ManagedVault {
             self.singleton.read().modify_delegation(pool_id, delegatee, delegation);
         }
 
+        fn pragma_oracle(self: @ContractState) -> ContractAddress {
+            self.pragma_oracle_address.read()
+        }
+
+        fn set_oracle(ref self: ContractState, oracle_address: ContractAddress) {
+            self.assert_owner();
+            assert!(self.pragma_oracle_address.read().is_zero(), "oracle-already-initialized");
+            self.pragma_oracle_address.write(oracle_address);
+        }
+
+        fn price(self: @ContractState, asset: ContractAddress) -> AssetPrice {
+            let AssetConfig {
+                pragma_key,
+                timeout,
+                number_of_sources,
+                start_time_offset,
+                time_window,
+                aggregation_mode,
+                ..,
+            } = self.get_asset_configuration(asset).expect('asset-not-approved');
+            let dispatcher = IPragmaABIDispatcher {
+                contract_address: self.pragma_oracle_address.read(),
+            };
+            let response = dispatcher.get_data(DataType::SpotEntry(pragma_key), aggregation_mode);
+
+            // calculate the twap if start_time_offset and time_window are set
+            assert!(start_time_offset != 0, "start-time-offset-must-be-set");
+            assert!(time_window != 0, "time-window-must-be-set");
+            let value = response.price.into() * SCALE / pow_10(response.decimals.into());
+
+            // ensure that price is not stale and that the number of sources is sufficient
+            let time_delta = if response.last_updated_timestamp >= get_block_timestamp() {
+                0
+            } else {
+                get_block_timestamp() - response.last_updated_timestamp
+            };
+            let is_valid = (timeout == 0 || (timeout != 0 && time_delta <= timeout))
+                && (number_of_sources == 0
+                    || (number_of_sources != 0
+                        && number_of_sources <= response.num_sources_aggregated));
+
+            AssetPrice { value, is_valid }
+        }
+        fn set_asset_configuration_parameter(
+            ref self: ContractState, asset: ContractAddress, parameter: felt252, value: felt252,
+        ) {
+            self.assert_owner();
+
+            let mut oracle_config: AssetConfig = self
+                .get_asset_configuration(asset)
+                .expect('asset-not-approved');
+            assert!(oracle_config.pragma_key != 0, "oracle-config-not-set");
+
+            if parameter == 'is_legacy' {
+                oracle_config.is_legacy = value == 0;
+            } else if parameter == 'scale' {
+                oracle_config.scale = value.try_into().unwrap();
+            } else if parameter == 'pragma_key' {
+                oracle_config.pragma_key = value;
+            } else if parameter == 'timeout' {
+                oracle_config.timeout = value.try_into().unwrap();
+            } else if parameter == 'number_of_sources' {
+                oracle_config.number_of_sources = value.try_into().unwrap();
+            } else if parameter == 'start_time_offset' {
+                oracle_config.start_time_offset = value.try_into().unwrap();
+            } else if parameter == 'time_window' {
+                oracle_config.time_window = value.try_into().unwrap();
+            } else {
+                assert!(false, "invalid-oracle-parameter");
+            }
+
+            assert_asset_config(oracle_config);
+            self.modify_asset_configuration(asset, oracle_config);
+            // self.emit(SetOracleParameter { asset, parameter, value });
+        }
+        /////////////////////////
+        // Manager functions
+        /////////////////////////
+
         fn claim_rewards(
             ref self: ContractState,
             rewards_contract: ContractAddress,
@@ -439,11 +532,11 @@ pub mod ManagedVault {
             self.assert_asset_approved(end_token);
             // TODO Should there be a config to tell if asset is legacy or not?
             let AssetConfig {
-                is_legacy: is_legacy_start_token, pool_id: start_token_pool_id,
+                is_legacy: is_legacy_start_token, ..,
             } = self.get_asset_configuration(start_token).unwrap();
             let balance_start_before = self.balance_of_self(start_token, is_legacy_start_token);
             let AssetConfig {
-                is_legacy: is_legacy_end_token, pool_id: end_token_pool_id,
+                is_legacy: is_legacy_end_token, ..,
             } = self.get_asset_configuration(end_token).unwrap();
             let balance_end_before = self.balance_of_self(end_token, is_legacy_end_token);
             // Do the swap
@@ -455,45 +548,25 @@ pub mod ManagedVault {
             let balance_end_after = self.balance_of_self(end_token, is_legacy_end_token);
             // Decide which token is in/out based on the balance change
             let is_selling_start_token = balance_start_after < balance_start_before;
-            let (
-                sell_token,
-                sell_token_pool_id,
-                sell_amount,
-                buy_token,
-                buy_token_pool_id,
-                buy_amount,
-            ) =
-                if is_selling_start_token {
+            let (sell_token, sell_amount, buy_token, buy_amount) = if is_selling_start_token {
                 assert!(balance_end_after > balance_end_before, "swap-balance-mismatch");
                 (
                     start_token,
-                    start_token_pool_id,
                     balance_start_before - balance_start_after,
                     end_token,
-                    end_token_pool_id,
                     balance_end_after - balance_end_before,
                 )
             } else {
                 assert!(balance_end_before > balance_end_after, "swap-balance-mismatch");
                 (
                     end_token,
-                    end_token_pool_id,
                     balance_end_before - balance_end_after,
                     start_token,
-                    start_token_pool_id,
                     balance_start_after - balance_start_before,
                 )
             };
 
-            self
-                .assert_fair_rate(
-                    sell_token,
-                    sell_token_pool_id,
-                    sell_amount,
-                    buy_token,
-                    buy_token_pool_id,
-                    buy_amount,
-                );
+            self.assert_fair_rate(sell_token, sell_amount, buy_token, buy_amount);
         }
 
         fn modify_position(
@@ -633,13 +706,11 @@ pub mod ManagedVault {
                 if read_asset == asset.contract_address {
                     continue;
                 }
-                let AssetConfig { is_legacy, pool_id } = config;
+                let AssetConfig { is_legacy, scale, .. } = config;
                 let balance = self.balance_of_self(read_asset, is_legacy);
-
-                let (collateral_asset_config, _) = singleton.asset_config(pool_id, read_asset);
-                let asset_price = extension.price(pool_id, read_asset);
-
-                assets += balance * asset_price.value / collateral_asset_config.scale;
+                let asset_price = self.price(read_asset);
+                assert_price(asset_price);
+                assets += balance * asset_price.value / scale;
             }
 
             assets - liabilities
@@ -705,5 +776,18 @@ pub mod ManagedVault {
                 .redemption_requests
                 .write(get_caller_address(), (get_block_timestamp(), shares, per_share_nav));
         }
+    }
+
+    pub fn assert_asset_config(asset_config: AssetConfig) {
+        assert!(asset_config.pragma_key != 0, "pragma-key-must-be-set");
+        assert!(
+            asset_config.time_window <= asset_config.start_time_offset,
+            "time-window-must-be-less-than-start-time-offset",
+        );
+    }
+
+    fn assert_price(price: AssetPrice) {
+        assert!(price.is_valid, "price-invalid");
+        assert!(price.value != 0, "price-zero");
     }
 }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -231,6 +231,15 @@ pub mod ManagedVault {
             assert!(self.get_asset_configuration(asset).is_some(), "asset-not-approved");
         }
 
+        #[inline(always)]
+        fn balance_of_self(self: @ContractState, asset: ContractAddress, is_legacy: bool) -> u256 {
+            if is_legacy {
+                IERC20Dispatcher { contract_address: asset }.balanceOf(get_contract_address())
+            } else {
+                IERC20Dispatcher { contract_address: asset }.balance_of(get_contract_address())
+            }
+        }
+
         fn assert_fair_rate(
             self: @ContractState,
             sell_token: ContractAddress,
@@ -419,7 +428,6 @@ pub mod ManagedVault {
 
         fn swap(ref self: ContractState, swap: Array<Swap>, limit_amount: u128) {
             self.assert_manager();
-            let this = get_contract_address();
 
             assert!(limit_amount > 0, "invalid-limit-amount");
             let start_token = *swap[0].route[0].pool_key.token0;
@@ -427,40 +435,22 @@ pub mod ManagedVault {
             let end_token = *last_swap.route[last_swap.route.len() - 1].pool_key.token1;
             self.assert_asset_approved(start_token);
             self.assert_asset_approved(end_token);
-            let start_token_dispatcher = IERC20Dispatcher { contract_address: start_token };
-            let end_token_dispatcher = IERC20Dispatcher { contract_address: end_token };
             // TODO Should there be a config to tell if asset is legacy or not?
             let AssetConfig {
                 is_legacy: is_legacy_start_token, pool_id: start_token_pool_id,
             } = self.get_asset_configuration(start_token).unwrap();
-            let balance_start_before = if is_legacy_start_token {
-                start_token_dispatcher.balanceOf(this)
-            } else {
-                start_token_dispatcher.balance_of(this)
-            };
+            let balance_start_before = self.balance_of_self(start_token, is_legacy_start_token);
             let AssetConfig {
                 is_legacy: is_legacy_end_token, pool_id: end_token_pool_id,
             } = self.get_asset_configuration(end_token).unwrap();
-            let balance_end_before = if is_legacy_end_token {
-                end_token_dispatcher.balanceOf(this)
-            } else {
-                end_token_dispatcher.balance_of(this)
-            };
+            let balance_end_before = self.balance_of_self(end_token, is_legacy_end_token);
             // Do the swap
             let _: () = call_core_with_callback(
                 self.ekubo_core.read(), @SwapParams { swap, limit_amount },
             );
 
-            let balance_start_after = if is_legacy_start_token {
-                start_token_dispatcher.balanceOf(this)
-            } else {
-                start_token_dispatcher.balance_of(this)
-            };
-            let balance_end_after = if is_legacy_end_token {
-                end_token_dispatcher.balanceOf(this)
-            } else {
-                end_token_dispatcher.balance_of(this)
-            };
+            let balance_start_after = self.balance_of_self(start_token, is_legacy_start_token);
+            let balance_end_after = self.balance_of_self(end_token, is_legacy_end_token);
             // Decide which token is in/out based on the balance change
             let is_selling_start_token = balance_start_after < balance_start_before;
             let (
@@ -616,15 +606,12 @@ pub mod ManagedVault {
                 position = self.position_list.next(position);
             }
 
-            let balance = if self.is_legacy.read() {
-                self.asset.read().balanceOf(this)
-            } else {
-                self.asset.read().balance_of(this)
-            };
+            let asset = self.asset.read();
+            let balance = self.balance_of_self(asset.contract_address, self.is_legacy.read());
 
             let (extension, pool_id) = self.price_source();
             let extension = IExtensionDispatcher { contract_address: extension };
-            let price = extension.price(pool_id, self.asset.read().contract_address);
+            let price = extension.price(pool_id, asset.contract_address);
             assets += balance * price.value / self.scale.read();
 
             // Loop through all approved assets and add their value
@@ -633,7 +620,7 @@ pub mod ManagedVault {
             // Should it keep track
 
             for asset_index in 0..self.asset_config.len() {
-                let (asset, config) = self.asset_config[asset_index].read();
+                let (local_asset, config) = self.asset_config[asset_index].read();
                 // Skip if the asset configuration was removed
                 if config == Default::default() {
                     continue;
@@ -641,18 +628,14 @@ pub mod ManagedVault {
 
                 // Skip if the asset is the vault's underlying asset
                 // This is important to avoid double counting the asset
-                if asset == self.asset.read().contract_address {
+                if local_asset == asset.contract_address {
                     continue;
                 }
                 let AssetConfig { is_legacy, pool_id } = config;
-                let balance = if is_legacy {
-                    IERC20Dispatcher { contract_address: asset }.balanceOf(this)
-                } else {
-                    IERC20Dispatcher { contract_address: asset }.balance_of(this)
-                };
+                let balance = self.balance_of_self(local_asset, is_legacy);
 
-                let (collateral_asset_config, _) = singleton.asset_config(pool_id, asset);
-                let asset_price = extension.price(pool_id, asset);
+                let (collateral_asset_config, _) = singleton.asset_config(pool_id, local_asset);
+                let asset_price = extension.price(pool_id, local_asset);
 
                 assets += balance * asset_price.value / collateral_asset_config.scale;
             }

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -156,8 +156,7 @@ pub mod ManagedVault {
         // Map of redemption requests
         // (user, (timestamp, shares, nav_per_share_at_request))
         redemption_requests: Map<ContractAddress, (u64, u256, u256)>,
-        // TODO Name
-        asset_list: Map<ContractAddress, bool>,
+        approved_asset: Map<ContractAddress, bool>,
         // storage for the timestamp manager component
         #[substorage(v0)]
         position_list: position_list_component::Storage,
@@ -315,11 +314,11 @@ pub mod ManagedVault {
 
         fn modify_asset(ref self: ContractState, asset: ContractAddress, is_approved: bool) {
             self.assert_owner();
-            self.asset_list.write(asset, is_approved);
+            self.approved_asset.write(asset, is_approved);
         }
 
         fn is_asset_approved(self: @ContractState, asset: ContractAddress) -> bool {
-            self.asset_list.read(asset)
+            self.approved_asset.read(asset)
         }
 
         fn set_redemption_timeout(ref self: ContractState, timeout: u64) {

--- a/src/managed_vault.cairo
+++ b/src/managed_vault.cairo
@@ -400,7 +400,8 @@ pub mod ManagedVault {
             ref self: ContractState, asset: ContractAddress, asset_configuration: AssetConfig,
         ) {
             self.assert_owner();
-            assert_asset_config(asset_configuration);
+            // Enabling this assertion would prevent to remove an asset configuration
+            // assert_asset_config(asset_configuration);
 
             for asset_index in 0..self.asset_config.len() {
                 let (read_asset, _) = self.asset_config[asset_index].read();

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -18,7 +18,9 @@ mod Test_896150_ManagedVault {
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
     use vesu::test::setup_v2::deploy_with_args;
     use vesu::units::SCALE;
-    use vesu_periphery::managed_vault::{IManagedVaultDispatcher, IManagedVaultDispatcherTrait};
+    use vesu_periphery::managed_vault::{
+        AssetConfig, IManagedVaultDispatcher, IManagedVaultDispatcherTrait,
+    };
     use vesu_periphery::multiply::IMultiplyDispatcher;
     use super::{IStarkgateERC20Dispatcher, IStarkgateERC20DispatcherTrait};
 
@@ -123,8 +125,15 @@ mod Test_896150_ManagedVault {
         cheat_caller_address(
             managed_vault.contract_address, get_contract_address(), CheatSpan::TargetCalls(2),
         );
-        managed_vault.modify_asset(usdc.contract_address, true);
-        managed_vault.modify_asset(eth.contract_address, true);
+        let is_legacy = false;
+        managed_vault
+            .modify_asset_configuration(
+                AssetConfig { asset: usdc.contract_address, pragma_id: 0, is_legacy },
+            );
+        managed_vault
+            .modify_asset_configuration(
+                AssetConfig { asset: eth.contract_address, pragma_id: 0, is_legacy },
+            );
 
         TestConfig {
             ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -127,13 +127,9 @@ mod Test_896150_ManagedVault {
         );
         let is_legacy = false;
         managed_vault
-            .modify_asset_configuration(
-                usdc.contract_address, Some(AssetConfig { pragma_id: 1, is_legacy }),
-            );
+            .modify_asset_configuration(usdc.contract_address, AssetConfig { is_legacy, pool_id });
         managed_vault
-            .modify_asset_configuration(
-                eth.contract_address, Some(AssetConfig { pragma_id: 2, is_legacy }),
-            );
+            .modify_asset_configuration(eth.contract_address, AssetConfig { is_legacy, pool_id });
 
         TestConfig {
             ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -120,11 +120,15 @@ mod Test_896150_ManagedVault {
         IStarkgateERC20Dispatcher { contract_address: usdt.contract_address }
             .permissioned_mint(user, 10010_000_000);
 
-        let test_config = TestConfig {
-            ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,
-        };
+        cheat_caller_address(
+            managed_vault.contract_address, get_contract_address(), CheatSpan::TargetCalls(2),
+        );
+        managed_vault.modify_asset(usdc.contract_address, true);
+        managed_vault.modify_asset(eth.contract_address, true);
 
-        test_config
+        TestConfig {
+            ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,
+        }
     }
 
     #[test]

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -128,11 +128,11 @@ mod Test_896150_ManagedVault {
         let is_legacy = false;
         managed_vault
             .modify_asset_configuration(
-                AssetConfig { asset: usdc.contract_address, pragma_id: 0, is_legacy },
+                usdc.contract_address, Some(AssetConfig { pragma_id: 1, is_legacy }),
             );
         managed_vault
             .modify_asset_configuration(
-                AssetConfig { asset: eth.contract_address, pragma_id: 0, is_legacy },
+                eth.contract_address, Some(AssetConfig { pragma_id: 2, is_legacy }),
             );
 
         TestConfig {

--- a/tests/test_managed_vault.cairo
+++ b/tests/test_managed_vault.cairo
@@ -18,6 +18,7 @@ mod Test_896150_ManagedVault {
     use vesu::singleton_v2::{ISingletonV2Dispatcher, ISingletonV2DispatcherTrait};
     use vesu::test::setup_v2::deploy_with_args;
     use vesu::units::SCALE;
+    use vesu::vendor::pragma::AggregationMode;
     use vesu_periphery::managed_vault::{
         AssetConfig, IManagedVaultDispatcher, IManagedVaultDispatcherTrait,
     };
@@ -101,6 +102,7 @@ mod Test_896150_ManagedVault {
             ekubo.contract_address.into(),
             multiply.contract_address.into(),
             0,
+            0x02a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b.try_into().unwrap(),
         ];
 
         let managed_vault = IManagedVaultDispatcher {
@@ -127,9 +129,33 @@ mod Test_896150_ManagedVault {
         );
         let is_legacy = false;
         managed_vault
-            .modify_asset_configuration(usdc.contract_address, AssetConfig { is_legacy, pool_id });
+            .modify_asset_configuration(
+                usdc.contract_address,
+                AssetConfig {
+                    is_legacy,
+                    scale: 1_000_000_000,
+                    pragma_key: 'USDC/USD',
+                    timeout: 60,
+                    number_of_sources: 1,
+                    start_time_offset: 1,
+                    time_window: 1,
+                    aggregation_mode: AggregationMode::Median,
+                },
+            );
         managed_vault
-            .modify_asset_configuration(eth.contract_address, AssetConfig { is_legacy, pool_id });
+            .modify_asset_configuration(
+                eth.contract_address,
+                AssetConfig {
+                    is_legacy,
+                    scale: 1_000_000_000_000_000_000,
+                    pragma_key: 'ETH/USD',
+                    timeout: 60,
+                    number_of_sources: 1,
+                    start_time_offset: 1,
+                    time_window: 1,
+                    aggregation_mode: AggregationMode::Median,
+                },
+            );
 
         TestConfig {
             ekubo, singleton, multiply, managed_vault, pool_id, pool_key, eth, usdc, usdt, user,


### PR DESCRIPTION
Building on top of update to 2.11.4

Add `assets_list` to be used as whitelist for enabled assets in the strategy
    - enforce in swaps
    - include these asset balances in NAV calculation
    - each asset needs a corresponding pragma feed

1. Didn't clearly understand where the pragma feed should be placed, thus that part isn't there yet. Is it replacing the price feed from Vesu to Pragma?

2. When performing a swap only approved assets are allowed. Meaning that if swap goes like “ETH => DOGE => USDC” and DOGE isn’t approved by the owner, it should proceed. We only care about start and end token.